### PR TITLE
Work on #1182: Add running phpcs to the technical docs

### DIFF
--- a/docs/technical-documentation/checking-coding-standards.md
+++ b/docs/technical-documentation/checking-coding-standards.md
@@ -1,0 +1,16 @@
+
+# Checking Code Style
+
+Before opening a pull request, you should check your code style. If you are using the [Vagrant](https://github.com/Islandora-Devops/claw-playbook), you can run `phpcs` within the Drupal installation directory (on the Vagrant, that is `/var/www/html/drupal`) or from within the `web` directory (`/var/www/html/drupal/web`) as follows:
+
+* from within Drupal's root directory: `./vendor/bin/phpcs --standard=./vendor/drupal/coder/coder_sniffer/Drupal modules/contrib/my_module`, where `modules/contrib/my_module` is the relative or full path to the PHP file you want to check.
+* from within Drupal's `web` directory: `../vendor/bin/phpcs --standard=../vendor/drupal/coder/coder_sniffer/Drupal yourfile`, where `yourfile` is the relative or full path to the PHP file you want to check.
+
+In both cases:
+
+* the path to the coding standard file can be relative to where you are running it from, e.g. when in `web`: `--standard=../vendor/drupal/coder/coder_sniffer/Drupal`
+* you can specify a single file to check, or a directory path; in the latter case, all files in that directory will be checked.
+
+Islandora 8 runs `phpcs` in its Travis continuous integration environment, and there, it specifies which files to ignore and which files to check. It is a good idea for developers to specify the same options when running `phpcs` locally, prior to opening a pull request. For example (running `phpcs` from the within Drupal's `web` directory), you should use the following `--ignore` and `--extensions` options:
+
+`../vendor/bin/phpcs --standard=../vendor/drupal/coder/coder_sniffer/Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info modules/contrib/my_module`


### PR DESCRIPTION
**GitHub Issue**: #1182 

This PR incorporates feedback from #1183 and #1207 and replaces those PRs.

# What does this Pull Request do?

Adds a new page to the technical documentation describing how to check your coding style.

# What's new?
A new .md file in the technical docuemenation directory.

# How should this be tested?
 Review it for clarity and completeness, and consistency with other docs.

# Interested parties
@Islandora-CLAW/committers
