### PR TITLE
Create readme_template.md 

### DIFF
--- a/docs/contributing/readme_template.md
+++ b/docs/contributing/readme_template.md
@@ -79,7 +79,7 @@
 
 `If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.`
 
-`We recommend using the [claw-playbook](https://github.com/Islandora-Devops/claw-playbook) to get started.  If you want to pull down the submodules for development, don't forget to run `git submodule update --init --recursive` after cloning.`
+``We recommend using the [claw-playbook](https://github.com/Islandora-Devops/claw-playbook) to get started.  If you want to pull down the submodules for development, don't forget to run `git submodule update --init --recursive` after cloning.``
 
 `Also include any Travis gotcha's here. `
 

--- a/docs/contributing/readme_template.md
+++ b/docs/contributing/readme_template.md
@@ -47,7 +47,7 @@
 
 `## Documentation`
 
-`Further documentation for this module is available [herehttps://islandora-claw.github.io/CLAW/]`
+`Further documentation for this module is available on the [Islandora 8 documentation site](https://islandora-claw.github.io/CLAW/).`
 
 `## Troubleshooting/Issues`
 

--- a/docs/contributing/readme_template.md
+++ b/docs/contributing/readme_template.md
@@ -1,0 +1,88 @@
+`# ![Alt text](Mascot Image) Repository Name `
+
+`[![Minimum PHP Version](link)](link)`
+`[![Build Status](link)](link)`
+`[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)`
+`[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)`
+`[![codecov](link)](link)`
+
+`## Introduction`
+
+`A brief introduction and summary of the module.`
+
+`## Requirements`
+
+`This module requires the following modules/libraries:`
+
+`* [Name](Link)`
+`* [Name](Link)`
+`* Any`
+`* Requirements`
+
+`## Installation`
+
+`Installations instructions.`
+
+`## Configuration`
+
+`Describe path to configuration. `
+
+`Include a screenshot of configuration page. When using your choice of screenshot software, resize your browser`
+`first to avoid wide screenshots. Here are a few browser extension examples to take screenshots.`
+
+  `* [Fireshots](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg)`
+  `* [Nimbus](https://chrome.google.com/webstore/detail/nimbus-screenshot-screen/bpconcjcammlapcogcnnelfmaeghhagj)`
+
+`To upload the image drag the image into the comment section of an existing Pull Request. `
+
+`This will generate the image url link for you`
+  `![Configuration Screenshot](https://user-images.githubusercontent.com/2857697/39014759-e2ef9c1e-43e0-11e8-921c-c2a3234d65d2.jpg)`
+
+`Video example on [How to attach an Image in README.md file with Github](https://youtu.be/wVHJtL-y7P0)`
+
+
+`## Other Sections As Needed`
+
+`Sections specific to this repo, but not found in all repos, should go here.`
+
+`## Documentation`
+
+`Further documentation for this module is available [herehttps://islandora-claw.github.io/CLAW/]`
+
+`## Troubleshooting/Issues`
+
+`Having problems or solved a problem? Check out the Islandora google groups for a solution.`
+
+`* [Islandora Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora)`
+`* [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)`
+
+`## FAQ`
+
+`Q. Is this normal?`
+
+`A. Yes. This is normal. Why ...`
+
+`## Maintainers/Sponsors`
+
+`Current maintainers:`
+
+`* [Maintainer Name](https://github.com/maintainer_github)`
+`* [Another Maintainer](https://github.com/maintainer_github)`
+
+`This project has been sponsored by:`
+
+`* Some really awesome sponsor`
+
+`## Development`
+
+`If you would like to contribute, please get involved by attending our weekly [Tech Call](https://github.com/Islandora-CLAW/CLAW/wiki). We love to hear from you!`
+
+`If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.`
+
+`We recommend using the [claw-playbook](https://github.com/Islandora-Devops/claw-playbook) to get started.  If you want to pull down the submodules for development, don't forget to run `git submodule update --init --recursive` after cloning.`
+
+`Also include any Travis gotcha's here. `
+
+`## License`
+
+`[Name](link). GPLv2 for Drupal modules. MIT for other modules. `


### PR DESCRIPTION
**GitHub Issue**: #1268 and #1267

# What does this Pull Request do?

Adds a document describing a template to follow for setting up readmes in Islandora 8 GitHub repos. Based heavily on the existing template for [Islandora 7](https://github.com/Islandora/islandora/wiki/Readme-template).  

# What's new?

New .md file in the contributing section of the documentation. 

# How should this be tested?

Test by previewing the document - but I'm also looking for evaluation of the format itself. Is this a good template/ Are there sections we should add?

# Additional Notes:

This could be done as a page in the github wiki, like it is for 7.x, but then there's no PR process for review.

# Interested parties
@Islandora-CLAW/committers because this will hit every repo
