### PR TITLE
fix link to documentation #1319

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more details, please check out the following resources:
   * [2018](https://github.com/Islandora-CLAW/CLAW/wiki/2018)
   * [2019](https://github.com/Islandora-CLAW/CLAW/wiki/2019)
 
-* [Documentation](https://islandora-claw.github.io/CLAW/)
+* [Documentation](https://islandora.github.io/documentation/)
 * [Contributing](https://github.com/Islandora-CLAW/CLAW/blob/master/CONTRIBUTING.md)
 
 ## Repository Structure


### PR DESCRIPTION
**GitHub Issue**:

#1319

# What does this Pull Request do?

Updates the README link to the documentation site from https://islandora-claw.github.io/CLAW/ (which doesn't work) to https://islandora.github.io/documentation/.

# How should this be tested?

click
