### PR TITLE
Github markdown doesn't allow for embedded videos

### DIFF
--- a/docs/technical-documentation/migrate-7x.md
+++ b/docs/technical-documentation/migrate-7x.md
@@ -1,3 +1,5 @@
-<iframe width="560" height="315" src="https://www.youtube.com/embed/fEDzfSPjKEo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+## Migrating from Islandora 7.x to Islandora CLAW (YouTube Video)
+
+[![Migrating from Islandora 7.x to Islandora CLAW](https://img.youtube.com/vi/fEDzfSPjKEo/0.jpg)](https://www.youtube.com/watch?v=fEDzfSPjKEo)
 
 For tools to migrate into Islandora 8 from an existing Islandora 7 instance, please see [migrate_7x_claw](https://github.com/Islandora-devops/migrate_7x_claw)


### PR DESCRIPTION
**GitHub Issue**: (link)
Corrects the page view within Github.

### From
![Screen Shot 2020-02-04 at 11 12 16 AM](https://user-images.githubusercontent.com/2738244/73763855-096f7580-4740-11ea-9d1e-f336f123c36c.png)

### To
![Screen Shot 2020-02-04 at 11 21 58 AM](https://user-images.githubusercontent.com/2738244/73764225-94507000-4740-11ea-9310-744f575d81e8.png)


# What does this Pull Request do?
Switches out the html `<embed>` with the Github suggested alternative for youtube videos.

# What's new?
Just the image.

# How should this be tested?
Make sure the image links to the correct spot and the thumb is correct.

# Additional Notes:
N/A

# Interested parties
@Islandora/8-x-committers
