### PR TITLE
Updating to drupal ^8.8.1

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -20,7 +20,7 @@ phpcs --config-set installed_paths /opt/utils/vendor/drupal/coder/coder_sniffer
 
 echo "Composer install drupal site"
 cd /opt
-git clone --branch 8.6.10 https://github.com/Islandora-CLAW/drupal-project.git drupal
+git clone --branch 8.8.1 https://github.com/Islandora-CLAW/drupal-project.git drupal
 cd drupal
 if [ -z "$COMPOSER_PATH" ]; then
   composer install


### PR DESCRIPTION
Note this actually gets you 8.8.4 at this point in time, but the tag is still 8.8.1

**GitHub Issue**: Related to https://github.com/Islandora/islandora_defaults/pull/26 and maybe https://github.com/Islandora/islandora/pull/764

# What does this Pull Request do?

Makes travis use Drupal ^8.8.1

# How should this be tested?

Restart Travis builds after merging this and see if it helps.  It's at least a piece of the puzzle.

# Interested parties
@Islandora/8-x-committers
