### PR TITLE
Adding links to Islandora Quick Lessons on Youtube in docs that align with the topics.

### DIFF
--- a/docs/user-documentation/blocks.md
+++ b/docs/user-documentation/blocks.md
@@ -97,3 +97,6 @@ If we edit the collection and change its model tag from "Collection" to anything
 
 As you can see, block placement can be very flexible, and allow you to customize your site in a very granular fashion.
 Between using core block placement and the context module, there's no block you can't get into the right place on your site.
+
+!!! Tip "Islandora Quick Lessons"
+    Learn more with this video on [Creating a Custom Block](https://youtu.be/4VUI9pOXpzE).

--- a/docs/user-documentation/collections.md
+++ b/docs/user-documentation/collections.md
@@ -71,3 +71,6 @@ for 'Member Of' is already filled out for you with the appropriate collection.
 ![You should see the widget for 'Member Of' is already filled out for you with the appropriate collection.](../assets/collections_member_of_selected.jpg)
 
 Click 'Save' at the end of the form to create the new item and add it as a member of the collection.
+
+!!! Tip "Islandora Quick Lessons"
+    Learn more with this video on [Making a Collection](https://youtu.be/9jFVAE6l4so).

--- a/docs/user-documentation/content_types.md
+++ b/docs/user-documentation/content_types.md
@@ -171,6 +171,10 @@ In some cases a repository may want a node or taxonomy term's `rdf:type` to be c
 
 `fieldMappings` specifies the fields to be included, their RDF property mappings, and any necessary data converters (the `datatype_callback`). One field can be mapped to more than one RDF property by adding them to the field's properties list. The `datatype_callback` is defined by the 'callable' key and the fully qualified static method used to convert it to the desired data format. For example, fields of the Drupal datetime type need to be converted to ISO 8601 values, so we use the `Drupal\rdf\CommonDataConverter::dateIso8601Value` function to perform the conversion.
 
+!!! Tip "Islandora Quick Lessons"
+    Learn more with this video on [Customizing a Form](https://youtu.be/tOW27DZY9hs).
+
+
 ## Further Reading:
 
 - [Drupal.org Introduction to Form API](https://www.drupal.org/docs/8/api/form-api/introduction-to-form-api)

--- a/docs/user-documentation/create_update_views.md
+++ b/docs/user-documentation/create_update_views.md
@@ -49,5 +49,8 @@ For this example, we create a new view as a block and place the new block to onl
 8. The 'Collection list' now only displays on the frontpage. It displays below the 'Main page content'.
 ![Frontpage view collection list](../assets/frontpage_view_collection_list.png)
 
+!!! Tip "Islandora Quick Lessons"
+    Learn more with videos on [Basic Views](https://youtu.be/Ge14g8nBUBQ) and [Advanced Views](https://youtu.be/inPRZeQGnKI).
+
 
 

--- a/docs/user-documentation/creating-a-node.md
+++ b/docs/user-documentation/creating-a-node.md
@@ -47,3 +47,7 @@ Click **Save** when done, and the file will be uploaded (to Fedora by default). 
 you created and you should see the image along with its descriptive metadata.
 
 ![The file is now loaded, return to the main site to view](../assets/final-loaded-image.jpg)
+
+!!! Tip "Islandora Quick Lessons"
+    Learn more with this video on [Adding Content](https://youtu.be/G52is7iFkG4).
+

--- a/docs/user-documentation/users.md
+++ b/docs/user-documentation/users.md
@@ -40,6 +40,9 @@ To review/edit the permission for each role, in the *People* page click the **Pe
 1. Scroll down or search for options that have an *Islandora* prefix or contain the word *Islandora*. For example, *Islandora Access: Create terms*.
 ![Alt text](../assets/users_permissions.png "Permissions page")
 
+!!! Tip "Islandora Quick Lessons"
+    Learn more with this video on how to [Add a User](https://youtu.be/XSokAFRVBuE).
+
 ## Further Reading on Managing Users in Drupal
 
 For more information on managing users in Drupal visit the section


### PR DESCRIPTION
**GitHub Issue**: #1487 

# What does this Pull Request do?

Adds links to videos from the [Islandora Quick Lessons](https://www.youtube.com/playlist?list=PL4seFC7ELUtripxWi_2RIBKCWqI0uif93) that match up with topics in our docs. I used the tip formatting to make their addition consistent across different pages.


# How should this be tested?

Preview & review. The tip formatting won't show up outside of built docs, [like this](https://islandora.github.io/documentation/user-documentation/collections/)

# Interested parties
@Islandora/8-x-committers
