### PR TITLE
Add landing page for video documentation to user docs

### DIFF
--- a/docs/user-documentation/video-docs.md
+++ b/docs/user-documentation/video-docs.md
@@ -1,0 +1,43 @@
+# Video Documentation
+
+Islandora Quick Lessons are a series of short videos demonstrating how to do common tasks in Islandora 8. 
+
+New videos are added to [the playlist]() regularly.
+
+## General Information
+
+- [What is Islandora?](https://youtu.be/nG6aidmQVZ4): A quick overview of what Islandora is and why people use it.
+
+## Installation & Virtual Machines
+
+- [Building a Virtual Machine](https://youtu.be/cFNWgfRY_Ec): How to build a new VM using the Islandora [ansible playbook](https://github.com/Islandora-Devops/islandora-playbook).
+- [Importing a Virtual Machine](https://youtu.be/Zv0XWz1kU5Q): How to import a VM from a downloaded .ova.
+- [Using an FTP Client on a VM](https://youtu.be/fBf0NuCEERw): How to configure an Islandora VM to work with an FTP client like [Cyberduck](https://cyberduck.io/) or [WinSCP](https://winscp.net/eng/download.php).
+- [Composer Module Install](https://youtu.be/ckbLy_1O5sI): How to use Composer to install new Drupal modules in your VM.
+
+## Site Building Basics
+
+- [Add a User](https://youtu.be/XSokAFRVBuE): How to make a new user who can add Islandora content.
+- [Creating a Basic Page](https://youtu.be/uuECIWG0RQY): How to create a regular Drupal page.
+- [Creating a Custom Block](https://youtu.be/4VUI9pOXpzE): How to create a custom content Block and place it on your site.
+- [Adding a Menu Item](https://youtu.be/IN_5DYq-lwU): How to add a new entry in your site's navigation.
+- [Setting a Home Page](https://youtu.be/PCK0oStyKHg): How to assign a particular Drupal node as the Home Page for your site.
+
+## Working with Islandora Content
+
+- [Add Content](https://youtu.be/G52is7iFkG4): How to add items to your Islandora repository.
+- [Making a Collection](https://youtu.be/9jFVAE6l4so): How to create a new Islandora collection.
+- [Adding a Taxonomy Term](https://youtu.be/FEb2yOWg140): How to add a new term to an existing Taxonomy in Islandora.
+- [Regerating a Derivative](https://youtu.be/g3xg1zDlBe0): How to force Islandora to re-create a derivative for a node.
+- [Customizing a Form](https://youtu.be/tOW27DZY9hs): How to modify fields, modify the ingest form, and modify the metadata display for Islandora content.
+- [Adding a New Context](https://youtu.be/T4yIfn_Se_s): How to add a new Context, causing a site Action to be performed based on conditions.
+- [Changing an Action](https://youtu.be/pkG6IRkh4wU): How to change how an existing Action behaves, to be performed based on a Context.
+- [Batch Ingest with Migrate](https://youtu.be/gXBgLkiOi0A): How to use Drupal Migrate to bulk-load Islandora content with metadata, without using the command line.
+
+
+## Working with Views
+
+- [Basic Views](https://youtu.be/Ge14g8nBUBQ): How to make a very basic View filtered by a taxonomy term.
+- [Advanced Views](https://youtu.be/inPRZeQGnKI): How to bring together several settings and tools to make a more advanced image view.
+- [Batch Editing](https://youtu.be/ZMp0lPelOZw): How to use Views Bulk Edit to create a batch editing view for Islandora.
+- [Export and Import a View](https://youtu.be/0NXrzSzxhLc): How to copy a custom View from one Islandora site to another.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Installation: 'installation.md'
   - User Documentation:
       - 'Introduction': 'user-documentation/user-intro.md'
+      - 'Video Documentation': 'user-documentation/video-docs.md'
       - 'Intro to Linked Data': 'user-documentation/intro-to-ld-for-islandora-8.md'
       - Content in Islandora 8:
         - 'Resource Nodes': 'user-documentation/resource-nodes.md'


### PR DESCRIPTION
**GitHub Issue**: #1487 

# What does this Pull Request do?

Adds a new page and corresponding entry in mkdocs.yml for an annotated and organized list of video documentation from Islandora Quick Lessons. 

# How should this be tested?

Preview & review. Please check links, read for typos, etc.

# Additional Notes:
The video docs already point back to the written documentation. This is to help make it easier to discover the videos from the main docs.

# Interested parties
@Islandora/8-x-committers
