### PR TITLE
Fix broken link and adjust for mkdocs-material version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 install:
   - pip install mkdocs
-  - pip install mkdocs-material==4.6.3
+  - pip install mkdocs-material
 
 script:
   - mkdocs build --clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 install:
   - pip install mkdocs
-  - pip install mkdocs-material
+  - pip install mkdocs-material==4.6.3
 
 script:
   - mkdocs build --clean

--- a/docs/inactive/different_from_7x.md
+++ b/docs/inactive/different_from_7x.md
@@ -2,7 +2,7 @@
 
 In the most basic terms, Islandora 8 is the version of Islandora that works with [Fedora 5](https://wiki.duraspace.org/display/FF/Fedora+Repository+Home). Because Fedora 4 and 5 are vastly different than Fedora 3, so too is Islandora 8 a major departure from what came before. Switching to Islandora 8 represents not just a typical upgrade with improvements, features, and bug fixes, but rather a major shift in how objects are stored and managed.
 
-Moving from Islandora 7.x-1.x to 8.x-1.x requires a migration of objects, which you can learn about [here](../migration/migration.md). It also requires some adjustments in how you think about your objects and their relationships, and how to manage them in Islandora, which we will cover below.
+Moving from Islandora 7.x-1.x to 8.x-1.x requires a migration of objects, which you can learn about [here](../inactive/migration.md). It also requires some adjustments in how you think about your objects and their relationships, and how to manage them in Islandora, which we will cover below.
 
 You can also check out some of the documentation provided by the Fedora project:
 * [Concept Mapping - Fedora 3 to 4](https://wiki.duraspace.org/display/FEDORA4x/Concept+Mapping+-+Fedora+3+to+4)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,8 @@ extra:
   palette:
     primary: 'red'
     accent: 'red'
-  logo: 'assets/claw.png'
   social:
-    - type: 'twitter'
+    - icon: fontawesome/brands/twitter
       link: 'https://twitter.com/islandora'
 
 nav:


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Fixes a warning from a broken link and pins the mkdocs version to 4.6.3 as there is (seemingly) a breaking in the new 5.* branch.

# How should this be tested?

Travis is green and publishes when merged.

# Interested parties
@Islandora/8-x-committers and @manez 
