### PR TITLE
Update index.md to add link to older docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,5 @@ As native Drupal content, Islandora resources can also be integrated with existi
 
 Islandora 8 comes with a comprehensive [default site configuration](https://github.com/Islandora/islandora_defaults) for Drupal to get you started, and even an [Ansible playbook](https://github.com/Islandora-Devops/islandora-playbook) that will quickly get you up and running so you can try it out.
 
-!!! note "Islandora 6 and 7" Documenation for earlier versions of Islandora is on our [documentation wiki](https://wiki.lyrasis.org/display/ISLANDORA/Start).
+!!! note "Islandora 6 and 7" 
+Documentation for earlier versions of Islandora is on our [documentation wiki](https://wiki.lyrasis.org/display/ISLANDORA/Start).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,5 @@ Out of the box, this includes:
 As native Drupal content, Islandora resources can also be integrated with existing Drupal tools like the [Solr Search API](https://www.drupal.org/project/search_api_solr), [Matomo Analytics](https://www.drupal.org/project/matomo), [RDF schema building](https://www.drupal.org/project/rdfui), and much more.
 
 Islandora 8 comes with a comprehensive [default site configuration](https://github.com/Islandora/islandora_defaults) for Drupal to get you started, and even an [Ansible playbook](https://github.com/Islandora-Devops/islandora-playbook) that will quickly get you up and running so you can try it out.
+
+!!! note "Islandora 6 and 7" Documenation for earlier versions of Islandora is on our [documentation wiki](https://wiki.lyrasis.org/display/ISLANDORA/Start).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,4 +16,4 @@ As native Drupal content, Islandora resources can also be integrated with existi
 Islandora 8 comes with a comprehensive [default site configuration](https://github.com/Islandora/islandora_defaults) for Drupal to get you started, and even an [Ansible playbook](https://github.com/Islandora-Devops/islandora-playbook) that will quickly get you up and running so you can try it out.
 
 !!! note "Islandora 6 and 7" 
-Documentation for earlier versions of Islandora is on our [documentation wiki](https://wiki.lyrasis.org/display/ISLANDORA/Start).
+    Documentation for earlier versions of Islandora is on our [documentation wiki](https://wiki.lyrasis.org/display/ISLANDORA/Start).


### PR DESCRIPTION
**GitHub Issue**: None

# What does this Pull Request do?

Adds a "note" at the bottom of the first page of our docs to indicate where users can find docs for 6 and 7 (the LYRASIS confluence wiki).

# How should this be tested?

Preview and review - with a little bit of trust, since the "note" format won't render until the docs are built, but when it does, it looks [like this](https://islandora.github.io/documentation/user-documentation/media/)

# Additional Notes:
There's a header on the 7 docs pointing to the 8 docs. Seems right to point the other way, especially since there are still many, many 7 sites still very much in production out there.

# Interested parties
@Islandora/8-x-committers
