### PR TITLE
Change ansible_ssh_host to ansible_host

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -195,7 +195,7 @@ for more details about what you can put into a
 host file
 
 ```
-default ansible_ssh_host=example.org ansible_ssh_user=root ansible_ssh_private_key_file='/home/username/.ssh/id_rsa'
+default ansible_host=example.org ansible_port=22 ansible_user=root ansible_ssh_private_key_file='/home/username/.ssh/id_rsa'
 ```
 
 ### Running the remote installer


### PR DESCRIPTION
**GitHub Issue**: #1547 

https://groups.google.com/d/msg/islandora/laIOtvxmyIc/VJd3Uv_zAwAJ

# What does this Pull Request do?

Changes `ansible_ssh_host` and `ansible_ssh_user` to `ansible_host` and `ansible_user` in the documentation for a remote install.

# Interested parties
@Islandora/8-x-committers
