### PR TITLE
Render the example helpful tip properly.

### DIFF
--- a/docs/contributing/docs_style_guide.md
+++ b/docs/contributing/docs_style_guide.md
@@ -10,19 +10,19 @@
 - Use `-` instead of `*` for bulleted lists.
 - Upload images to the 'assets' folder and reference them from there. 
    -- For file name, use underscores between words and prefix all file names with the page name, e.g. context_display_hints.jpg for the image showing how to set display hints in the context menu.
-- Use the [Admonition syntax](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) to create notes like this:
+- Use the [Admonition syntax](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) to create notes like this (four-space indent required):
 
 _Example:_
 
 ```
 !!! note "Helpful Tip" 
-  I am a helpful tip!
+    I am a helpful tip!
 ```
 
 _Result:_
 
 !!! note "Helpful Tip" 
-  I am a helpful tip!
+    I am a helpful tip!
 
 
 ## Don'ts

--- a/docs/contributing/docs_style_guide.md
+++ b/docs/contributing/docs_style_guide.md
@@ -10,9 +10,20 @@
 - Use `-` instead of `*` for bulleted lists.
 - Upload images to the 'assets' folder and reference them from there. 
    -- For file name, use underscores between words and prefix all file names with the page name, e.g. context_display_hints.jpg for the image showing how to set display hints in the context menu.
-- Use `!!! note  "Note title"` at the start of a paragraph to have it rendered as a note like this:
+- Use the [Admonition syntax](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) to create notes like this:
 
-!!! note "Helpful Tip" I am a helpful tip!
+_Example:_
+
+```
+!!! note "Helpful Tip" 
+  I am a helpful tip!
+```
+
+_Result:_
+
+!!! note "Helpful Tip" 
+  I am a helpful tip!
+
 
 ## Don'ts
 


### PR DESCRIPTION
## Purpose / why

There was an example of the syntax to create a "Helpful tip" - it was wrong, and on github.io it wasn't rendering.

## What changes were made?

Put the text of the tip on a newline indented four spaces, also provided a link to the "Admonition" extension where this behaviour is documented.

## Verification

You'll have to `mkdocs serve` to see if it renders locally.

## Interested Parties

@manez 


---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
