### PR TITLE
Fix committer nomination email address

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -89,6 +89,6 @@ If they accept, then do:
 
 1. Add to the Islandora 8 Committer team of the Github Islandora organization.
 2. Add to Committer team of GitHub Islandora-Labs organization 
-3. Add to islandora-2x-committers google-group
+3. Add to islandora-committers google-group
 4. Add to committers wiki page: Islandora 8 Committers (this page)
 5. Announce the new committer ([template/committerAnnounce.txt](https://raw.githubusercontent.com/Islandora/documentation/master/docs/contributing/templates/committerAnnounce.txt))

--- a/docs/contributing/templates/closeCommitterVote.txt
+++ b/docs/contributing/templates/closeCommitterVote.txt
@@ -1,4 +1,4 @@
-To: islandora-7x-2x-committers@googlegroups.com
+To: islandora-committers@googlegroups.com
 Subject: RESULT Vote new Islandora CLAW Committer candidate: [Nominee]
 
 Body:

--- a/docs/contributing/templates/closeCommitterVote.txt
+++ b/docs/contributing/templates/closeCommitterVote.txt
@@ -1,5 +1,5 @@
 To: islandora-committers@googlegroups.com
-Subject: RESULT Vote new Islandora CLAW Committer candidate: [Nominee]
+Subject: RESULT Vote new Islandora 8 Committer candidate: [Nominee]
 
 Body:
 =================================

--- a/docs/contributing/templates/committerAnnounce.txt
+++ b/docs/contributing/templates/committerAnnounce.txt
@@ -3,12 +3,12 @@ Subject: New committer: [New Committer]
 
 Body:
 ================================
-The Islandora CLAW committers have asked [New Committer] to become a committer and we are pleased to announce that they have accepted.
+The Islandora 8 committers have asked [New Committer] to become a committer and we are pleased to announce that they have accepted.
 
 ### add specific details here ###
 
 Further details of the rights and responsibilities of being a Islandora committer can be found here:
-http://islandora-claw.github.io/CLAW/contributing/committers/
+http://islandora.github.io/documentation/contributing/committers/
 
 Regards,
 

--- a/docs/contributing/templates/committerInvite.txt
+++ b/docs/contributing/templates/committerInvite.txt
@@ -2,20 +2,20 @@ To: [Invitee]
 
 Subject:
 ===================================
-Invitation to become Islandora CLAW committer: [Invitee]
+Invitation to become Islandora 8 committer: [Invitee]
 ===================================
 
 Body:
 ===================================
 Hello [Invitee],
 
-The Islandora CLAW Committers Team hereby offers you committer privileges to the Islandora project. These privileges are offered on the understanding that you'll use them reasonably and with common sense. We like to work on trust rather than unnecessary constraints.
+The Islandora 8 Committers Team hereby offers you committer privileges to the Islandora project. These privileges are offered on the understanding that you'll use them reasonably and with common sense. We like to work on trust rather than unnecessary constraints.
 
 Being a committer does not require you to participate any more than you already do. It does tend to make one even more committed. You will probably find that you spend more time here. Of course, you can decline and instead remain as a contributor, participating as you do now. The specific rights and responsibilities of being an Islandora committer can be found here:
-http://islandora-claw.github.io/CLAW/contributing/committers/
+http://islandora.github.io/documentation/contributing/committers/
 
 This personal invitation is a chance for you to accept or decline in private. Either way, please let us know.
 
 Best regards,
-(on behalf of the Islandora CLAW Committers)
+(on behalf of the Islandora 8 Committers)
 ===================================

--- a/docs/contributing/templates/committerInviteCLA.txt
+++ b/docs/contributing/templates/committerInviteCLA.txt
@@ -2,17 +2,17 @@ To: [Invitee]
 
 Subject:
 ===================================
-Invitation to become Islandora CLAW committer: [Invitee]
+Invitation to become Islandora 8 committer: [Invitee]
 ===================================
 
 Body:
 ===================================
 Hello [Invitee],
 
-The Islandora CLAW Committers Team hereby offers you committer privileges to the Islandora project. These privileges are offered on the understanding that you'll use them reasonably and with common sense. We like to work on trust rather than unnecessary constraints.
+The Islandora 8 Committers Team hereby offers you committer privileges to the Islandora project. These privileges are offered on the understanding that you'll use them reasonably and with common sense. We like to work on trust rather than unnecessary constraints.
 
 Being a committer does not require you to participate any more than you already do. It does tend to make one even more committed. You will probably find that you spend more time here. Of course, you can decline and instead remain as a contributor, participating as you do now. The specific rights and responsibilities of being an Islandora committer can be found here:
-http://islandora-claw.github.io/CLAW/contributing/committers/
+http://islandora.github.io/documentation/contributing/committers/
 
 A. This personal invitation is a chance for you to accept or decline in private. Either way, please let us know.
 

--- a/docs/contributing/templates/committerVote.txt
+++ b/docs/contributing/templates/committerVote.txt
@@ -1,4 +1,4 @@
-To: islandora-7x-2x-committers@googlegroups.com
+To: islandora-committers@googlegroups.com
 Subject: Vote new committer: [Candidate]
 
 Body:


### PR DESCRIPTION
## Purpose / why

I recently tried nominating a committer using the process outlined here and noticed the email address that was mentioned was out of date.

De-CLAWing relates to: https://github.com/Islandora/documentation/issues/1082

## What changes were made?

Updated to the new email address for the Islandora 8 committers list. While I was modifying the templates I also noticed that they referenced CLAW, so I did a bit of de-clawing as well.

## Interested Parties

@dannylamb @Islandora/8-x-committers 

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
