### PR TITLE
Change edit link path to main.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_description: Documentation for Islandora 8
 
 dev_addr: 'localhost:8111'
 repo_url: https://github.com/Islandora/documentation
+edit_uri: 'edit/main/docs/'
 
 theme:
   name: 'material'


### PR DESCRIPTION
## Purpose / why

Fix #1546 - the links to edit the documentation were set to 'master' not main. 

The [mkdocs documentation](https://www.mkdocs.org/user-guide/configuration/) shows it needs to be set in the mkdocs config, or it defaults to master.

## What changes were made?

set 'edit_uri' which mkdocs defaulted to `edit/master/docs/` to be `edit/main/docs`.

## Verification

Do the links work?

## Interested Parties

@Islandora/8-x-committers

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
