### PR TITLE
Fix nested listing and indentation.

### DIFF
--- a/docs/contributing/docs_style_guide.md
+++ b/docs/contributing/docs_style_guide.md
@@ -2,14 +2,21 @@
 
 ## Do's
 
-- Submit documentation formatted in [Markdown](https://en.wikipedia.org/wiki/Markdown) format.
-  -- Please add Markdown headings to the content sections.
 - Use a GitHub Pull Request to submit documentation.
+- Submit documentation formatted in [Markdown](https://en.wikipedia.org/wiki/Markdown) format.
+    - Include a top-level heading for the whole page (using `#`)
+    - Please add Markdown headings (`#` and `##`) to the content sections.
+
 - Use the "bold/emphasis" style in Markdown for UI elements that users will interact with. For example, a button label for a button that must be pressed should be made bold in Markdown.
 - Use the "italics" style in Markdown for UI elements that have a label or title if you need to reference them in the documentation. For example, a title of a screen or page that will visit should be made italic in Markdown.
-- Use `-` instead of `*` for bulleted lists.
+- Use `-` instead of `*` for bulleted lists. Indent four (4) spaces for nested lists (Github renders nesting in markdown with 2 spaces, but mkdocs needs 4).
+_Example:_
+```
+- I am a list item
+    - And I am a sub-item.
+```
 - Upload images to the 'assets' folder and reference them from there. 
-   -- For file name, use underscores between words and prefix all file names with the page name, e.g. context_display_hints.jpg for the image showing how to set display hints in the context menu.
+    - For file naming, use underscores between words and prefix all file names with the page name, e.g. context_display_hints.jpg for the image showing how to set display hints in the context menu.
 - Use the [Admonition syntax](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) to create notes like this (four-space indent required):
 
 _Example:_

--- a/docs/technical-documentation/migration-overview.md
+++ b/docs/technical-documentation/migration-overview.md
@@ -12,12 +12,10 @@ The three options are:
 ### REST API
 
 Why use the rest API?
-- Works anywhere
-    - You don’t have to work on the Drupal server. Migrate from your laptop!
-- No PHP required
-    - Use any language that can make an http request. Even cURL will do just fine.
-- JSON
-    - Why use XML if you don’t have to?
+
+- **Works anywhere**: You don’t have to work on the Drupal server. Migrate from your laptop!
+- **No PHP required**: Use any language that can make an http request. Even cURL will do just fine.
+- **JSON**: Why use XML if you don’t have to?
 
 BONUS: It’s just Drupal’s REST API
 

--- a/docs/technical-documentation/migration-overview.md
+++ b/docs/technical-documentation/migration-overview.md
@@ -33,6 +33,7 @@ Just be aware, you are writing everything yourself! (In other words you are maki
 Uses the Drupal 8 [Migrate API](https://www.drupal.org/docs/8/api/migrate-api/migrate-api-overview), which "provides services for migrating data from a source system to Drupal 8.
 
 The "source system" can be almost anything:
+
 - an Islandora 7 system
 - a group of scanned images and their metadata inside a CSV file
 - a web API
@@ -59,6 +60,7 @@ Why use the Migrate API?
     - A tool to get all your Islandora 7 content migrated over
 
 ##### Recap of migrate_islandora_csv
+
 - CSVs
     - Everyone understands and knows how to work with CSVs
 - Documented

--- a/docs/technical-documentation/migration-overview.md
+++ b/docs/technical-documentation/migration-overview.md
@@ -13,20 +13,20 @@ The three options are:
 
 Why use the rest API?
 - Works anywhere
-  - You don’t have to work on the Drupal server. Migrate from your laptop!
+    - You don’t have to work on the Drupal server. Migrate from your laptop!
 - No PHP required
-  - Use any language that can make an http request. Even cURL will do just fine.
+    - Use any language that can make an http request. Even cURL will do just fine.
 - JSON
-  - Why use XML if you don’t have to?
+    - Why use XML if you don’t have to?
 
 BONUS: It’s just Drupal’s REST API
 
 #### Islandora only provides two additional API endpoints
 
 - /media/{mid}/source
-  - PUT a file to this endpoint to create/update a Media’s file
+    - PUT a file to this endpoint to create/update a Media’s file
 - /node/{nid}/media/{media_type}/{taxonomy_term}
-  - PUT a file to this endpoint to create/update a Media for a Node
+    - PUT a file to this endpoint to create/update a Media for a Node
 
 Just be aware, you are writing everything yourself! (In other words you are making all of the migration decisions yourself.)
 
@@ -56,41 +56,41 @@ Why use the Migrate API?
 #### We’ve built two tools for you using the Migrate API
 
 - [migrate_islandora_csv](https://github.com/Islandora/migrate_islandora_csv)
-  - Tutorial with a sample migration using some files and a CSV
+    - Tutorial with a sample migration using some files and a CSV
 - [migrate_7x_claw](https://github.com/Islandora-Devops/migrate_7x_claw)
-  - A tool to get all your Islandora 7 content migrated over
+    - A tool to get all your Islandora 7 content migrated over
 
 ##### Recap of migrate_islandora_csv
 - CSVs
-  - Everyone understands and knows how to work with CSVs
+    - Everyone understands and knows how to work with CSVs
 - Documented
-  - It’s a step-by-step walkthrough
+    - It’s a step-by-step walkthrough
 - Process Metadata
-  - Clean up / transform the metadata using processors
+    - Clean up / transform the metadata using processors
 - Build Relationships
-  - Migrations can reference other migrated content or generate new content on the fly
+    - Migrations can reference other migrated content or generate new content on the fly
 
 ##### Recap of migrate_7x_claw
 
 - Designed to migrate Islandora 7 data to Islandora 8.
 - DATASTREAMS
-  - All of your datasteams, including the audit trail, are migrated
+    - All of your datasteams, including the audit trail, are migrated
 - METADATA
-  - Migrate metadata from Solr or any XML datastream
+    - Migrate metadata from Solr or any XML datastream
 - CUSTOMIZABLE
-  - Migrate_7x_claw is a starting point, meant to be tailored to your metadata
+    - Migrate_7x_claw is a starting point, meant to be tailored to your metadata
 
 ###### To make migrate_7x_claw work you need
 
 - Access
-  - You need credentials to both your Islandora 7 and 8 installs.
+    - You need credentials to both your Islandora 7 and 8 installs.
 - Migrate API Knowledge
-  - The tutorial for migrate_islandora_csv
+    - The tutorial for migrate_islandora_csv
 Is still relevant
 - Config Sync
-  - You need to understand Drupal config synchronization.  Features knowledge helps too.
+    - You need to understand Drupal config synchronization.  Features knowledge helps too.
 - Command Line Skills
-  - This is best done with shell access and drush
+    - This is best done with shell access and drush
 
 #### Migrate API demo video
 
@@ -110,13 +110,13 @@ More tailored for end users with less technical knowledge or limited server acce
 #### Islandora Workbench highlights
 
 - Opinionated
-  - MUCH less configuration. Decisions made for you.
+    - MUCH less configuration. Decisions made for you.
 - No Processing
-  - CSV has to be in the right format
+    - CSV has to be in the right format
 - Write Operations
-  - Create, Update, and Delete content
+    - Create, Update, and Delete content
 - Bumpers On
-  - Configuration and CSV are validated
+    - Configuration and CSV are validated
 
 #### Islandora Workbench basics
 
@@ -128,24 +128,24 @@ More tailored for end users with less technical knowledge or limited server acce
 Islandora Workbench - Taxonomy Terms:
 
 - Can use term id, term name, or both
-  - 26
-  - Cats
-  - 26|Cats
+    - 26
+    - Cats
+    - 26|Cats
 - If using multiple vocabularies, prefix with vocabulary id:
-  - cats:Calico|dogs:Dachshund
+    - cats:Calico|dogs:Dachshund
 - Terms that don’t exist can be created
 
 Islandora Workbench - More Field Types:
 
 - Typed Relations - Prefix term ids with namespace:rel:
-  - relators:pht:30
-  - Relators:pht:30|relators:pub:45
+    - relators:pht:30
+    - Relators:pht:30|relators:pub:45
 -  Geolocation fields - “Lat,Long”
-  - "49.16667,-123.93333"
+    - "49.16667,-123.93333"
 
 Paged Content - Two Ways:
 
 - Metadata on Parent
-  - Simple directory structure and filename convention
+    - Simple directory structure and filename convention
 - Page Level Metadata
-  - Parent and page metadata in same CSV
+    - Parent and page metadata in same CSV


### PR DESCRIPTION
## Purpose / why

In the Migration overview page, the nested listing didn't render properly.

## What changes were made?

Used four spaces instead of two to indent! Github works with 2, but mkdocs needs 4.

## Verification

Does the pretty version look right?

## Interested Parties

@ysuarez  

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
