### PR TITLE
Update objects_to_resource_nodes.md

### DIFF
--- a/docs/user-documentation/objects_to_resource_nodes.md
+++ b/docs/user-documentation/objects_to_resource_nodes.md
@@ -1,4 +1,4 @@
- # From Objects to Resource Nodes: Shifting Concepts from Islandora 7 to 8
+# From Objects to Resource Nodes: Shifting Concepts from Islandora 7 to 8
 
 This document attempts to show the shift in how objects work from Islandora version 7 to version 8, from a non-developer perspective.
 


### PR DESCRIPTION
## Purpose / why

Fixes a title that was not being rendered properly by mkdocs.

## What changes were made?

Removes a single leading space from the wrong place.

## Verification

Making sure this fixed the problem will require building the docs locally https://islandora.github.io/documentation/technical-documentation/docs-build/

See [the page](https://islandora.github.io/documentation/user-documentation/objects_to_resource_nodes/) now and see "From Objects to Resource Nodes: Shifting Concepts from Islandora 7 to 8" is plain text with a stray hash mark. Build the docs from this PR, see how "From Objects to Resource Nodes: Shifting Concepts from Islandora 7 to 8" is now a proper H1 heading.


## Interested Parties

@Islandora/8-x-committers another simple type fix

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [x] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [x] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [x] If pages are renamed or removed, have all internal links to those pages been fixed?
* [x] If pages are added, have they been linked to or placed in the menu?
* [x] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
