### PR TITLE
Update updating_drupal.md

### DIFF
--- a/docs/technical-documentation/updating_drupal.md
+++ b/docs/technical-documentation/updating_drupal.md
@@ -40,7 +40,8 @@ If there is no line starting with drupal/core, Composer isn't aware of any updat
 
 If you want to know all packages that will be updated by the update command, use the --dry-run option first.
 
-!!! note "Alternate syntax needed": Islandora 8 is configured to use a fork of drupal-composer/drupal-project which requires a specific composer syntax used above compared to other Drupal 8 sites. In addition, if you are upgrading from 8.5 to 8.7, you need to replace "~8.5.x" with "^8.7.0" for drupal/core and webflo/drupal-core-require-dev in composer.json. [[Source](https://www.drupal.org/docs/8/update/update-core-via-composer#s-one-step-update-instruction)]
+!!! note "Alternate syntax needed"
+    Islandora 8 is configured to use a fork of drupal-composer/drupal-project which requires a specific composer syntax used above compared to other Drupal 8 sites. In addition, if you are upgrading from 8.5 to 8.7, you need to replace "~8.5.x" with "^8.7.0" for drupal/core and webflo/drupal-core-require-dev in composer.json. [[Source](https://www.drupal.org/docs/8/update/update-core-via-composer#s-one-step-update-instruction)]
 
 3) Apply any required database updates using ``drush updatedb``, or use the web admin user interface.  
 

--- a/docs/technical-documentation/updating_drupal.md
+++ b/docs/technical-documentation/updating_drupal.md
@@ -24,7 +24,8 @@ The Islandora community STRONGLY recommends that the "Composer" method of upgrad
 
 ### Here is an overview of the steps for updating Drupal core using Composer
 
-!!! "Back Up" First make sure you have made database and file back ups.
+!!! note "Back Up" 
+    First make sure you have made database and file back ups.
 
 1) First, verify that an update of Drupal core actually is available:
 
@@ -60,4 +61,6 @@ For more information about how to update Drupal modules visit:
 
 https://www.drupal.org/docs/8/extending-drupal-8/updating-modules
 
-!!! "Back Up" First make sure you have made database and file back ups.
+!!! note "Back Up" 
+    First make sure you have made database and file back ups.
+


### PR DESCRIPTION
## Purpose / why

Fixes a couple of note boxes on the Updating Drupal page that were not being rendered properly by mkdocs.

## What changes were made?

Spacing and `note` is needed to make the notes show up in pretty blue boxes in our built docs.

## Verification

Making sure this fixed the problem will require building the docs locally https://islandora.github.io/documentation/technical-documentation/docs-build/

See [the page](https://islandora.github.io/documentation/technical-documentation/updating_drupal/) now and see the two "Back Up" notes aren't showing up correctly. Build the docs from this PR, see nice blue Note boxes.

## Interested Parties

@Islandora/8-x-committers

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
