### PR TITLE
Remove extra info from readme.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ That is great! In this case please send us a pull request as described in the se
 
 ### Contribute code
 
-Before you set out to contribute code you will need to have completed a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). The signed copy of the license agreement should be sent to <mailto:community@islandora.ca>
+Before you set out to contribute code or documentation you will need to have completed a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). The signed copy of the license agreement should be sent to <mailto:community@islandora.ca>
 
 _If you are interested in contributing code to Islandora but do not know where to begin:_
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you would like to submit a use case to the Islandora 8 project, please submit
 
 ### Documentation
 
-You can contribute documentation in two different ways. One way is to create an issue [here](https://github.com/Islandora/documentation/issues/new), prepending "Documentation:" to the title of the issue. Another way is by pull request, which is the same process as [Contribute Code](https://github.com/Islandora/documentation/blob/main/CONTRIBUTING.md#contribute-code). All documentation resides in [`docs`](https://github.com/Islandora/documentation/tree/main/docs).
+You can contribute documentation in two different ways. One way is to create an issue [here](https://github.com/Islandora/documentation/issues/new), prepending "Documentation:" to the title of the issue. Another way is by pull request, which is the same process as [Contribute Code](https://github.com/Islandora/documentation/blob/main/CONTRIBUTING.md#contribute-code) and requires the same Contributor License Agreements. All documentation resides in [`docs`](https://github.com/Islandora/documentation/tree/main/docs).
 
 ### Request a new feature
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,17 @@
 
 [Read the documentation online](https://islandora.github.io/documentation/)
 
-## About the Documentation
+## About this Repository
 
-This repository contains source code for the user, developer, and administrator documentation for versions 8.x and above of the [Islandora project](https://islandora.ca/). It is written in mkdocs and can be viewed on [our Github Pages site](https://islandora.github.io/documentation/).
+This "documentation" repository has three funtions:
 
-## Issues
+- it houses the source code for the [documentation](https://islandora.github.io/documentation/) of the [Islandora project](https://islandora.ca/) (versions 8.x and above). 
+- its [Wiki](https://github.com/Islandora/documentation/wiki) contains the minutes for Islandora 8 Tech calls and User calls.
+- it hosts the central [issue queue](https://github.com/Islandora/documentation/issues) for the entire Islandora 8 project.
 
-File issues relating to this documentation in [this repository's issue queue](https://github.com/Islandora/documentation/issues), and apply the "documentation" label.
+## Documentation Structure
 
-This repository's issue queue is also the Islandora-wide issue queue for Islandora versions 8 and above. Issues may be applicable to repositories in all Islandora-associated github organizations, including [Islandora](https://github.com/Islandora), [Islandora DevOps](https://github.com/Islandora-Devops), [Islandora Labs](https://github.com/Islandora-Labs), and [Islandora Interest Groups](https://github.com/islandora-interest-groups).
-
-## Deployment
-
-This repository is deployed to Github Pages automatically when new commits are added to the main branch.
+The documentation is written in [mkdocs](https://www.mkdocs.org/) - the navigation structure is specified in `mkdocs.yml` and the `/docs/` folder contains the content. The text is written in mkdocs-flavoured markdown format and follows our [Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/). Documentation is built and deployed to Github Pages automatically when new commits are added to the 'main' branch. 
 
 * [Islandora 8 Documentation via Github Pages](https://islandora.github.io/documentation/)
 
@@ -25,17 +23,10 @@ Documentation for Islandora 7.x and previous versions is hosted by Lyrasis on a 
 
 * [Documentation for Islandora 7.x and earlier](https://wiki.lyrasis.org/display/ISLANDORA/)
 
-
-## Repository Structure
-
-In this repository, the /docs/ folder contains the documentation in markdown format. The mkdocs.yml file in the root directory specifies the navigation menu.
-
 ## Maintainers
 
 * [Documentation Interest Group](https://github.com/islandora-interest-groups/Islandora-Documentation-Interest-Group)
 
-
 ## Contributing
 
 To contribute to the Islandora documentation, create an issue or a pull request. To have a pull request accepted, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](https://islandora.ca/contribute) pages on Islandora.ca for more information.
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## About this Repository
 
-This "documentation" repository has three funtions:
+This "documentation" repository has three functions:
 
 - it houses the source code for the [documentation](https://islandora.github.io/documentation/) of the [Islandora project](https://islandora.ca/) (versions 8.x and above). 
 - its [Wiki](https://github.com/Islandora/documentation/wiki) contains the minutes for Islandora 8 Tech calls and User calls.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,41 @@
-# ![Islandora 8](https://camo.githubusercontent.com/738dd7cbd90a3ef06b9bb55a4cf5ed385a048fd4/687474703a2f2f69736c616e646f72612e63612f73697465732f64656661756c742f66696c65732f696d616765732f6c6f6273746572434c41572e706e67) Islandora 8 Documentation
+# Islandora 8 Documentation
+![Islandora 8](https://camo.githubusercontent.com/738dd7cbd90a3ef06b9bb55a4cf5ed385a048fd4/687474703a2f2f69736c616e646f72612e63612f73697465732f64656661756c742f66696c65732f696d616765732f6c6f6273746572434c41572e706e67)
 
-## About this repository (github.com/Islandora/documentation)
+[Read the documentation online](https://islandora.github.io/documentation/)
 
-This repository contains the user, developer, and administrator documentation for the [Islandora project](https://islandora.ca/), for versions 8 and above. This documentation is available to read at https://islandora.github.io/documentation/, where it is automatically deployed on commit from the source code at https://github.com/Islandora/documentation. Documentation for Islandora 7.x and previous versions is available at https://wiki.lyrasis.org/display/ISLANDORA/. 
+## About the Documentation
 
-This repository's issue queue is the [Islandora-wide issue queue](https://github.com/Islandora/documentation/issues) for Islandora versions 8 and above. Issues may be applicable to repositories in all Islandora-associated github organizations, including [Islandora](https://github.com/Islandora), [Islandora DevOps](https://github.com/Islandora-Devops), [Islandora Labs](https://github.com/Islandora-Labs), and [Islandora Interest Groups](https://github.com/islandora-interest-groups). Issues for Islandora 7.x and previous versions is available at https://jira.lyrasis.org/projects/ISLANDORA/issues.
+This repository contains source code for the user, developer, and administrator documentation for versions 8.x and above of the [Islandora project](https://islandora.ca/). It is written in mkdocs and can be viewed on [our Github Pages site](https://islandora.github.io/documentation/).
 
+## Issues
 
-## What is Islandora 8?
+File issues relating to this documentation in [this repository's issue queue](https://github.com/Islandora/documentation/issues), and apply the "documentation" label.
 
-Islandora 8 is the next generation of Islandora. It pairs [Drupal 8](https://www.drupal.org/8) with [Fedora 5](https://wiki.duraspace.org/display/FF/Fedora+Repository+Home)
+This repository's issue queue is also the Islandora-wide issue queue for Islandora versions 8 and above. Issues may be applicable to repositories in all Islandora-associated github organizations, including [Islandora](https://github.com/Islandora), [Islandora DevOps](https://github.com/Islandora-Devops), [Islandora Labs](https://github.com/Islandora-Labs), and [Islandora Interest Groups](https://github.com/islandora-interest-groups).
 
-For more details, please check out the following resources:
+## Deployment
 
-* [Documentation](https://islandora.github.io/documentation/)
-* [Contributing](https://github.com/Islandora/documentation/blob/main/CONTRIBUTING.md)
+This repository is deployed to Github Pages automatically when new commits are added to the main branch.
 
-* [Weekly Tech Calls](https://github.com/Islandora/documentation/wiki#islandora-8-tech-calls)
-  * [2015](https://github.com/Islandora/documentation/wiki/2015)
-  * [2016](https://github.com/Islandora/documentation/wiki/2016)
-  * [2017](https://github.com/Islandora/documentation/wiki/2017)
-  * [2018](https://github.com/Islandora/documentation/wiki/2018)
-  * [2019](https://github.com/Islandora/documentation/wiki/2019)
-  * [2020](https://github.com/Islandora/documentation/wiki/2020)
+* [Islandora 8 Documentation via Github Pages](https://islandora.github.io/documentation/)
+
+## Older versions
+
+Documentation for Islandora 7.x and previous versions is hosted by Lyrasis on a Confluence wiki.
+
+* [Documentation for Islandora 7.x and earlier](https://wiki.lyrasis.org/display/ISLANDORA/)
 
 
 ## Repository Structure
 
-This repository pulls in additional documentation from the following repositories, which is reflected in the repository tree.
-
-* [Alpaca](https://github.com/islandora/Alpaca): Event driven middleware based on Apache Camel that synchronizes a Fedora with Drupal.
-* [docs](https://github.com/Islandora/documentation/tree/main/docs): Documentation!
-* [carapace](https://github.com/islandora/carapace/): A starter theme for an Islandora 8 repository. 
-* [chullo](https://github.com/islandora/chullo/): PHP client for Fedora 4 built using Guzzle and EasyRdf.
-* [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook): Ansible installer.
-* [controlled_access_terms](https://github.com/islandora/controlled_access_terms/): Drupal module for subjects and agents. 
-* [Crayfish](https://github.com/islandora/Crayfish): A collection of Islandora 8 microservices.
-* [Crayfish-Commons](https://github.com/Islandora/Crayfish-Commons): A library housing shared code for Crayfish microservices
-* [drupal-project](https://github.com/Islandora/drupal-project): Composer template for Islandora 8 Drupal
-* [islandora](https://github.com/Islandora/islandora/tree/8.x-1.x): Islandora 8 Drupal core module
-* [islandora_defaults](https://github.com/Islandora/islandora_defaults): Starter configuration for an Islandora 8 repository 
-* [jsonld](https://github.com/islandora/jsonld): JSON-LD Serializer for Drupal 8
-* [migrate_islandora_csv](https://github.com/Islandora/migrate_islandora_csv): Tutorial and example migration into Islandora 8 using a CSV file.
-* [migrate_7x_claw](https://github.com/Islandora-Devops/migrate_7x_claw): Starter migration for Islandora 7 -> 8.
-* [openseadragon](https://github.com/islandora-claw/openseadragon): Drupal 8 Field Formatter for OpenSeadragon
-* [Syn](https://github.com/islandora/Syn): Tomcat valve for JWT Authentication
-
-
-## Installation
-Islandora 8 can be deployed either via Docker Compose using [ISLE](https://islandora.github.io/documentation/installation/docker-compose/) for a development or single-server environment, or via an Ansible [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to fully deploy the stack to a vagrant, bare-metal server or multi server environments. 
-
-## Sponsors
-
-* UPEI
-* discoverygarden inc.
-* LYRASIS
-* McMaster University
-* University of Limerick
-* York University
-* University of Manitoba
-* Simon Fraser University
-* PALS
-* American Philosophical Society
-* Common Media Inc.
+In this repository, the /docs/ folder contains the documentation in markdown format. The mkdocs.yml file in the root directory specifies the navigation menu.
 
 ## Maintainers
 
-* [Melissa Anez](https://github.com/manez/)
-* [Daniel Lamb](https://github.com/dannylamb/)
-* [Jared Whiklo](https://github.com/whikloj)
+* [Documentation Interest Group](https://github.com/islandora-interest-groups/Islandora-Documentation-Interest-Group)
 
-## Development
 
-If you would like to contribute, please get involved by attending our weekly [Tech Call](https://github.com/Islandora/documentation/wiki#islandora-8-tech-calls). We love to hear from you!
+## Contributing
 
-If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.
+To contribute to the Islandora documentation, create an issue or a pull request. To have a pull request accepted, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](https://islandora.ca/contribute) pages on Islandora.ca for more information.
 
-We recommend using the Docker-based [ISLE](https://islandora.github.io/documentation/installation/docker-compose/) or the Ansible-based [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to get started.  If you want to pull down the submodules for development, don't forget to run `git submodule update --init --recursive` after cloning.


### PR DESCRIPTION
## Purpose / why

The readme was like a mini documentation about the Islandora project. I streamlined it and tried to redirect viewers to the github pages.

## What changes were made?

Removed the submodules bit, and the section where they were described as part of "this repository's structure". 

I took out A LOT that was islandora-related: 
* installation
* sponsors
* links to the tech calls
* changed 'maintainers' to a link to the DIG

## Verification

Please comment if you think that some of this needs to be back in, in one form or another!

## Interested Parties

@manez @dannylamb @eldonquijote (Jeff Rubin?)

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
