### PR TITLE
Admonition for lobster

### DIFF
--- a/docs/contributing/docs_style_guide.md
+++ b/docs/contributing/docs_style_guide.md
@@ -38,21 +38,20 @@ _Result:_
 !!! note "Helpful Tip" 
     I am a helpful tip!
     
-- Use the [Callout syntax](https://rdmd.readme.io/docs/callouts) with a lobster emoji 🦞 to call attention to areas where Islandora configuration differs from standard Drupal configuration:
+- Use our custom `islandora` type within the Admonition syntax to call attention to areas where Islandora configuration differs from standard Drupal configuration:
 
 _Example:_
 
 ```
-> 🦞 Islandora
-> 
-> This setting is specific to Islandora and is not standard to Drupal.
+!!! islandora "Lobster trap"
+    This setting is specific to Islandora and is not standard to Drupal.
+
 ```
 
 _Result:_
 
-> 🦞 Islandora
-> 
-> This setting is specific to Islandora and is not standard to Drupal.
+!!! islandora "Lobster trap"
+    This setting is specific to Islandora and is not standard to Drupal.
 
 ## Don'ts
 

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,20 @@
+
+.md-typeset .admonition.islandora,
+.md-typeset details.islandora {
+  border-color: rgb(194, 19, 19);
+}
+.md-typeset .islandora > .admonition-title,
+.md-typeset .islandora > summary {
+  background-color: rgba(194, 19, 19, 0.1);
+}
+.md-typeset .islandora > .admonition-title::before,
+.md-typeset .islandora > summary::before {
+  content: "🦞";
+}
+
+.markdown-body .callout[theme="islandora"] {
+  --background: #c54245;
+  --border: #ffffff6b;
+  --text: #f5fffa;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,8 @@ theme:
   language: 'en'
 markdown_extensions:
   - admonition
+extra_css:
+  - css/custom.css
 
 extra:
   font:


### PR DESCRIPTION
It didn't work as pretty as I expected - I think we'd have to install the "callouts" extension (which is like same same but different. So I rewrote it with Admonitions so we're not inviting utter chaos?

To be honest callouts look nicer (and sound gentler) than admonitions. Maybe at next DIG we could propose switching? (the Css would be easier too)

Here's what I got: 

<img width="749" alt="Screen Shot 2020-11-12 at 7 05 49 PM" src="https://user-images.githubusercontent.com/1943338/99007259-38f6ae00-251a-11eb-9650-dfd50f1528a5.png">
