### PR TITLE
expose user docs content more readily

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,24 +78,23 @@ nav:
       # distinguish for instance between 'user' who can create/consume 
       # repository content (curator) and repository manager, who has access 
       # to configuration options that a curator should not meddle with
-      - Content in Islandora 8:
-          # moved from Repository admin section
-          # largely conceptual, repository managers and to some extent curators
-        - 'Resource Nodes': 'user-documentation/resource-nodes.md'
-              # largely conceptual, repository managers; move out procedural 
-              # information (e.g. move procedure for setting display hints to 
-              # documentation about contexts)
-        - 'Media': 'user-documentation/media.md'
-              # conceptual and procedural, repository managers
-              # move out procedural description for deleting Media
-        - 'Collections': 'user-documentation/collections.md'
-              # conceptual and procedural, repository managers/ curators
-              # move out procedural description for creating and populating collections
-        - 'Paged Content': 'user-documentation/paged-content.md'
-              # conceptual and procedural, repository managers/ curators
-              # move out procedural description for ordering pages
-        - 'Metadata': 'user-documentation/metadata.md'
-              # largely conceptual, repository managers/ curators
+        # moved from Repository admin section
+        # largely conceptual, repository managers and to some extent curators
+      - 'Resource Nodes': 'user-documentation/resource-nodes.md'
+            # largely conceptual, repository managers; move out procedural 
+            # information (e.g. move procedure for setting display hints to 
+            # documentation about contexts)
+      - 'Media': 'user-documentation/media.md'
+            # conceptual and procedural, repository managers
+            # move out procedural description for deleting Media
+      - 'Collections': 'user-documentation/collections.md'
+            # conceptual and procedural, repository managers/ curators
+            # move out procedural description for creating and populating collections
+      - 'Paged Content': 'user-documentation/paged-content.md'
+            # conceptual and procedural, repository managers/ curators
+            # move out procedural description for ordering pages
+      - 'Metadata': 'user-documentation/metadata.md'
+            # largely conceptual, repository managers/ curators
       - 'Create a Resource Node': 'user-documentation/creating-a-node.md'
               # conceptual and procedural, repository managers/ curators
               # describes concepts, configuration options for Media nodes and and a procedure


### PR DESCRIPTION
## Purpose / why

To learn about nodes and media a user MUST open the "user " docs but then know that the very vague "content" label holds what they are looking for. 

## What changes were made?

Puts Nodes/Media etc up one level

## Verification

Does it compile? 

## Interested Parties

@manez @eldonquijote 
---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
