### PR TITLE
Address #1718 menu issues.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,11 +38,11 @@ extra:
       link: 'https://twitter.com/islandora'
 
 nav:
-  - About:
-      - 'This is Islandora': 'index.md'
-      # Conceptual, all user roles: should contain high-level information about
-      # what everybody needs to know to understand Islandora and interact with it
-      # Possibly add page/section: How to use this documentation (containing user role definitions)
+  - 'About': 'index.md'
+  # Conceptual, all user roles: should contain high-level information about
+  # what everybody needs to know to understand Islandora and interact with it
+  # Possibly add page/section: How to use this documentation (containing user role definitions)
+  - Concepts:
       - 'Component Overview': 'installation/component_overview.md'
           # moved from "Installation" section; alternatively duplicate a simplified version in the overview section
           # also see Architecture Diagram in Developer documentation


### PR DESCRIPTION
## Purpose / why

Address #1718 When the menu is collapsed into hamburger-lines, the landing page shows only the "About section" menu, which looks like the whole docs are real small!

## What changes were made?

Pulled the main page out to be the "About" page, on the top level of the nav menu.

## Verification

Test locally

## Interested Parties

@Islandora/8-x-committers @dannylamb 

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [x] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [x] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [x] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [x] If pages are renamed or removed, have all internal links to those pages been fixed?
* [x] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
