### PR TITLE
Add copyright line to mkdocs.yml (#1725)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ extra:
     - icon: fontawesome/brands/twitter
       link: 'https://twitter.com/islandora'
 
-copyright: <b>Some info about contributing can go here!</b><br>Change this in the <i>copyright</i> line in mkdocs.yml
+copyright: <b>This documentation is user-sourced!</b> Suggestions and comments are welcome in our <u><a href="https://github.com/Islandora/documentation/issues" target="_blank">issue queue</a></u>.
 
 nav:
   - 'About': 'index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ extra:
     - icon: fontawesome/brands/twitter
       link: 'https://twitter.com/islandora'
 
+copyright: <b>Some info about contributing can go here!</b><br>Change this in the <i>copyright</i> line in mkdocs.yml
+
 nav:
   - 'About': 'index.md'
   # Conceptual, all user roles: should contain high-level information about


### PR DESCRIPTION
## Purpose / why

> _Add lines to footer to facilitate linking to resources._

## What changes were made?

> _Added copyright line to mkdocs.yml_

## Note

> _The dummy lines must be changed to something useful before pushing to production._

## Verification

> These two dummy lines should appear in the footer above the Made with Material for MkDocs line
Some info about contributing can go here!
Change this in the copyright line in mkdocs.yml 

## Interested Parties

> _*@Islandora/8-x-committers_

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [x] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [x] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [x] If pages are renamed or removed, have all internal links to those pages been fixed?
* [x] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
