### PR TITLE
Update docs_style_guide.md: Remove "Last Updated" instructions

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -1,7 +1,5 @@
 # Islandora 8 Committers
 
-_last updated on 30-11-2020_
-
 Islandora 8 is open source and released under MIT and GPLv2 licenses. The software and associated documentation is developed collectively by a community of contributors and committers. All interested community members are encouraged to contribute to the project. Contributors who demonstrate sustained engagement with the project through quality participation in meetings, mailing lists, documentation and code updates can be nominated by existing committers to also become a committers. It should be emphasized that committers need not be limited to software developers. Community members with skills in documentation and testing, for example, can also be committers.
 
 ## Rights

--- a/docs/contributing/create_issues.md
+++ b/docs/contributing/create_issues.md
@@ -1,7 +1,5 @@
 # Create a GitHub Issue
 
-_last updated on 04-12-2020_
-
 ## Overview
 The Islandora community uses GitHub issues to track bug reports, requests for improvements, requests for new features, and use cases. Issues are welcome from anyone who works with Islandora.
 

--- a/docs/contributing/docs_style_guide.md
+++ b/docs/contributing/docs_style_guide.md
@@ -1,10 +1,8 @@
 # Documentation Style Guide
-_last updated on 09-11-2020_
 
 ## Do's
 
 - Use a GitHub Pull Request to submit documentation.
-- Add or update a line at the top of the page, just under the header, with the format `_last updated on DD-MM-YYYY_` when you add a page or make changes.
 - Make it clear if the documentation is based on a particular configuration (such as Islandora Defaults) or if it applies to any deployment of Islandora.
 - Submit documentation formatted in [Markdown](https://en.wikipedia.org/wiki/Markdown) format.
     - Include a top-level heading for the whole page (using `#`)

--- a/docs/technical-documentation/docs-build.md
+++ b/docs/technical-documentation/docs-build.md
@@ -1,7 +1,5 @@
 # Introduction
 
-_last updated on 15-12-2020_
-
 This documentation is built using [mkdocs](http://www.mkdocs.org/), a static site generator that is geared towards building project documentation. The documentation is created in the [Markdown](http://en.wikipedia.org/wiki/Markdown) format, and it all resides in the [`docs`](https://github.com/Islandora/documentation/tree/main/docs) directory in the repository. The organization of the documentation is controlled by the [`mkdocs.yml`](https://github.com/Islandora/documentation/blob/main/mkdocs.yml) in the root of the repository.
 
 !!! Tip "Video version available"

--- a/docs/tutorials/create-a-resource-node.md
+++ b/docs/tutorials/create-a-resource-node.md
@@ -1,4 +1,3 @@
-_last updated on 24-11-2020_
 
 ## Overview
 

--- a/docs/user-documentation/access-control.md
+++ b/docs/user-documentation/access-control.md
@@ -1,7 +1,5 @@
 # Access Control in Islandora
 
-_last updated on 2021-01-26_
-
 This page is about controlling **who can view or edit your Islandora content** (metadata and binaries). 
 
 Islandora recommends using Drupal's access control features. Contributed modules such as those described below, can provide additional flexibility and configurability. However, these only apply when content is accessed through Drupal, and are not applied to data in Fedora, the Triplestore, or Solr. 

--- a/docs/user-documentation/file_viewers.md
+++ b/docs/user-documentation/file_viewers.md
@@ -1,8 +1,5 @@
 # File Viewers
 
-_last updated on 03-12-2020_
-
-
 ## What are viewers?
 
 [Viewers](../glossary#viewer) allow site builders to display files in interactive javascript-based widgets, that provide functionality like zooming in/out, turning pages, playing/pausing, viewing in full screen, etc. 

--- a/docs/user-documentation/glossary.md
+++ b/docs/user-documentation/glossary.md
@@ -1,4 +1,3 @@
-_last updated on 13-11-2020_
 
 The following glossary of terms addresses an Islandora 8 context. When comparing new Islandora and Fedora to older versions it may also be helpful to reference [the Islandora 7 Glossary](https://wiki.duraspace.org/display/ISLANDORA/APPENDIX+E+-+Glossary).
 

--- a/docs/user-documentation/metadata.md
+++ b/docs/user-documentation/metadata.md
@@ -1,7 +1,5 @@
 # Metadata in Islandora 8
 
-_last updated on 12-18-2020_
-
 > TL;DR: In Islandora 8, metadata is stored in Drupal, in _fields_ attached to _entities_ (nodes or media). This allows us to interact with metadata (add, edit, remove, display, index in a search engine...) almost entirely using standard Drupal processes. If exporting this metadata to Fedora and/or a triplestore, the values are serialized to RDF using mappings that can be set for each bundle.
 
 !!! note "Drupal 8 Terminology"

--- a/docs/user-documentation/video-docs.md
+++ b/docs/user-documentation/video-docs.md
@@ -1,7 +1,5 @@
 # Video Documentation
 
-_last updated on 26-11-2020_
-
 Islandora Quick Lessons are a series of short videos demonstrating how to do common tasks in Islandora 8. 
 
 New videos are added to [the playlist]() regularly.


### PR DESCRIPTION
## Purpose / why

Remove manual "last updated" line from Style Guide, since #1743 make it moot by adding it automatically to the end of every page.

## What changes were made?

One style guide suggestions is gone as it the part of the page that followed that style.

## Verification

Preview & review is enough for this. Only content changes, no mkdocs trickery.

## Interested Parties

@Islandora/documentation 

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
