### PR TITLE
Change in recommended Karaf version

### DIFF
--- a/docs/installation/manual/installing_karaf_and_alpaca.md
+++ b/docs/installation/manual/installing_karaf_and_alpaca.md
@@ -48,7 +48,7 @@ sudo tar -xzvf karaf.tar.gz
 sudo chown -R karaf:karaf KARAF_DIRECTORY
 sudo mv KARAF_DIRECTORY/* /opt/karaf
 ```
-- `KARAF_TARBALL_LINK`: It’s recommended to get the most recent version of Karaf 4.x. This will depend on the current version of Karaf, which can be found on the [Karaf downloads page](https://karaf.apache.org/download.html) under “Karaf Runtime”. Like Solr, you can’t directly `wget` these links, but clicking on the `.tar.gz` link for the binary distribution will bring you to a list of mirrors, as well as provide you with a recommended mirror you can use here.
+- `KARAF_TARBALL_LINK`: It’s recommended to get the most recent version of Karaf 4.2.x. This will depend on the current version of Karaf, which can be found on the [Karaf downloads page](https://karaf.apache.org/download.html) under “Karaf Runtime”. Like Solr, you can’t directly `wget` these links, but clicking on the `.tar.gz` link for the binary distribution will bring you to a list of mirrors, as well as provide you with a recommended mirror you can use here.
 - `KARAF_DIRECTORY`: This will depend on the exact version being used, but will likely be `/opt/apache-karaf-VERSION`, where `VERSION` is the current Karaf version number.
 
 ### Configuring Karaf Logging


### PR DESCRIPTION
## Purpose / why

Following the manual install instructions for Karaf caused some failures to occur when installing Karaf features using Karaf 4.3. Jared Whiklo recommended trying Karaf 4.2 which did not seem to have the same problems.

Full discussion can be found at https://groups.google.com/g/islandora/c/w2TBTwVWTSU

## What changes were made?

Changed recommended Karaf version from 4.x to 4.2.x

## Verification

Removing Karaf from the Vagrant box (Islandora 8 1.1.0) and then manually installing Karaf 4.3.x will cause some features to fail.

## Interested Parties


@Islandora/8-x-committers

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
