### PR TITLE
Fix for milliner config variable

### DIFF
--- a/docs/installation/manual/installing_crayfish.md
+++ b/docs/installation/manual/installing_crayfish.md
@@ -169,7 +169,7 @@ syn:
 ---
 fedora_base_url: http://localhost:8080/fcrepo/rest
 drupal_base_url: http://localhost
-gemini_base_uri: http://localhost/gemini
+gemini_base_url: http://localhost/gemini
 modified_date_predicate: http://schema.org/dateModified
 strip_format_jsonld: true
 debug: false


### PR DESCRIPTION
## Purpose / why

Milliner needs a gemini_base_url variable but the variable given in the manual installation instructions was gemini_base_uri

## What changes were made?

Changed the variable name in the Milliner config file

## Verification

Following manual install instructions or changing the Milliner config in a working copy of Islandora to the one specified in the manual install instructions causes Milliner to complain about a missing variable.

## Interested Parties


@Islandora/8-x-committers_

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
