### PR TITLE
Link glossary to page.

### DIFF
--- a/docs/user-documentation/glossary.md
+++ b/docs/user-documentation/glossary.md
@@ -8,7 +8,7 @@ Event-driven middleware based on [Apache Camel](http://camel.apache.org/) that s
  CLAW (CLAW Linked Asset WebDataFrameWork) was the development code name for the software released in June, 2019 as _Islandora 8_.
  
 ## Collection
-Collections are a way of grouping related objects together in Islandora. They function much like directories on a computer; a collection can “contain” any number of related resource nodes and sub-collections. 
+A [collection](../concepts/collection.md) is a way of grouping related resources together, much like a directory on a computer. Collections can “contain” any number of related resource nodes and sub-collections.
 
 ## Crayfish
 A collection of Islandora 8 [microservices](#microservice). Some of the microservices are built specifically for use with a Fedora Repository and API-X, while others are just for general use within Islandora 8.


### PR DESCRIPTION
## Purpose / why

Collections is a page now, let's link the glossary to it. 

## What changes were made?

Replaced some text to make it more readable and added a link.

## Verification

does it link to the correct place (it does in my build)

## Interested Parties

@Islandora/documentation 
---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
