### PR TITLE
Add python script to get TOC as tree

### DIFF
--- a/make-nav-tree.py
+++ b/make-nav-tree.py
@@ -1,0 +1,28 @@
+#!/usr/local/bin/python3
+
+import yaml
+from treelib import Node, Tree
+
+def expand_yaml_to_tree(data, tree, parent = None):
+  label = list(data.keys())[0]
+  if parent == None:
+    tree.create_node(label, label)
+  else:
+    tree.create_node(label, label, parent = parent)
+  if type(data[label]) == list:
+    for branch in data[label]:
+      tree = expand_yaml_to_tree(branch, tree, label)
+  return tree
+
+with open('mkdocs.yml','r') as mkdocs:
+  full_file_contents = yaml.safe_load(mkdocs)
+  forest = []
+  for top_level_item in full_file_contents['nav']:
+    tree = Tree()
+    tree = expand_yaml_to_tree(top_level_item, tree)
+    forest.append(tree)
+      
+for tree in forest:    
+  tree.show()
+
+


### PR DESCRIPTION
## Purpose / why

The DIG wanted the spreadsheet re-done with the new table of contents, done up with one-word-per-line as a tree. You can do it in Vim but it takes a long time so I wrote a script in python. 

## What changes were made?

New python 3 script (may be 2-compatible) You may need to:
- install the modules pyyaml and treelib
- change the first line because your python may be in a different place.


## Verification

Please test and tell me what's missing.

## Interested Parties


@eldonquijote

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
