### PR TITLE
Update travis to use mkdocs insiders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 install:
   - pip install mkdocs
-  - pip install mkdocs-material
+  - pip install git+https://${MKDOCS_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
   - pip install mkdocs-git-revision-date-localized-plugin
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 install:
   - pip install mkdocs
-  - pip install git+https://${MKDOCS_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+  - pip install git+https://${GITHUB_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
   - pip install mkdocs-git-revision-date-localized-plugin
 
 script:


### PR DESCRIPTION
## Purpose / why

> Enable premium fetaures of mkdocs-material

## What changes were made?

> Added an access token, and am using it to install premium mkdocs-material in travis

## Verification

> Still figuring that out, honestly.  We need to use a premium feature to test.

## Interested Parties

> @Islandora/documentation 

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
