### PR TITLE
Update PULL_REQUEST_TEMPLATE.md to suggest docs team callout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Interested Parties
 
 
-> _**Replace this text** - name some folks who may be interested, or, if unsure, @Islandora/8-x-committers_
+> _**Replace this text** - Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/8-x-committers_
 
 ---
 


### PR DESCRIPTION
## Purpose / why

I recently could not remember the call out for the documentation group, so I wanted to add it to the PR template.

## What changes were made?

Added a reference to the GIthub callout for the docs team in the PR template.

## Verification



## Interested Parties

@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
