### PR TITLE
Added "make command not found" failure fix

### DIFF
--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -109,6 +109,9 @@ Pulling traefik    ... done
 Pulling watchtower ... done
 ```
 
+!!! Fail "Troubleshooting - make command not found"
+    If you get the error `bash: make: command not found` then you need to install GNU make. Run `sudo apt update` and `sudo apt install make` to install.
+
 !!! Fail "Troubleshooting - Docker Versions"
     If you get an error such as: `ERROR: Version in "./docker-compose.activemq.yml" is unsupported.`, then you need to upgrade Docker. Enter the command `make clean` before re-attempting to `make demo`.
 


### PR DESCRIPTION


## Purpose / why

I skimmed the directions and got the error "make command not found". Others might, too.

## What changes were made?

Added description of error and the fix.

## Verification

I spell checked? 

## Interested Parties

@Islandora/documentation 
---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
