### PR TITLE
Use different theme for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ branches:
 
 install:
   - pip install mkdocs
-  - pip install git+https://${GITHUB_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pip install mkdocs-material; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pip install git+https://${GITHUB_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git; fi'
   - pip install mkdocs-git-revision-date-localized-plugin
 
 script:


### PR DESCRIPTION
## Purpose / why

Travis is breaking on PR's, as it can't use the github token to access the mkdocs-material-insiders theme. this is expected Travis behaviour for security reasons.

https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions

Switch to using normal Material for PRs. 

> _**Replace this text** - Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/8-x-committers_

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
