### PR TITLE
Site site_url for mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_description: Documentation for Islandora 8
 
 dev_addr: 'localhost:8111'
 repo_url: https://github.com/Islandora/documentation
+site_url: https://islandora.github.io/documentation/
 edit_uri: 'edit/main/docs/'
 
 theme:


### PR DESCRIPTION
Since mkdocs v1.2 `site_url` is now required.

* Update mkdocs.yml

## Purpose / why

Bring back the clean URL's that are indexed in Google

## What changes were made?

Added `site_url` to mkdocs.yml

## Verification

Build mkdocs and see that directories are created for each page, instead of .html pages

https://www.mkdocs.org/user-guide/configuration/#site_url

## Interested Parties


@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)? #1853
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
