### PR TITLE
Fix TUS module url

### DIFF
--- a/docs/technical-documentation/uploading-large-files.md
+++ b/docs/technical-documentation/uploading-large-files.md
@@ -9,5 +9,5 @@ However, large file transfer over HTTP still has a host of issues once you prope
 Uploads are not resumable and subject to connectivity issues.
 If you really want to upload large files, you should consider some alternatives such as
 
-- Robertson library's [TUS](https://github.com/roblib/rdm_tus) module, which will let you upload large files in forms.
+- Using the [TUS file upload protocol](https://www.drupal.org/project/tus) module, which will let you upload large files in forms.
 - Using [flysystem](https://www.drupal.org/project/flysystem)'s ftp and sftp plugins to make files available if you can run an FTP server.


### PR DESCRIPTION
## Purpose / why

Updated the TUS module url to the drupal module page.

## What changes were made?

Updated the URL

## Interested Parties

@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
