### PR TITLE
Remove last updated date requirement from PR Template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,6 @@
 * [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
 * [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
 * [ ] Are the changes accurate, useful, free of typos, etc?
-* [ ] Does this PR update the _last updated on_ date on the documentation page?
 
 > __Person merging__ should ensure the following
 * [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)


### PR DESCRIPTION
## Purpose / why

The theme now includes a 'last updated' feature, we dont have to include it ourselves! Removing the instruction from the template of the PR. 

## What changes were made?

Removed extra line.

## Verification

n/a

## Interested Parties


 @Islandora/documentation,

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)? None.
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?
* [ ] Does this PR update the _last updated on_ date on the documentation page? *hahaha*

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
