### PR TITLE
Added line about COMPOSE_PROJECT_NAME

### DIFF
--- a/docs/installation/docker-local.md
+++ b/docs/installation/docker-local.md
@@ -23,7 +23,15 @@ set
 ```
 ENVIRONMENT=local
 ```
- 
+
+You should also change the `COMPOSE_PROJECT_NAME` variable. This determines the name of the 
+Docker containers that are created when you run `make local`. If you leave this as the default
+you will need to be careful not to overwrite the containers with another install of `isle-dc`
+later.
+```
+COMPOSE_PROJECT_NAME=isle-dc
+```
+
 If your site includes exported configuration from `drush config:export`, then you'll also
 need to set 
 


### PR DESCRIPTION
## Purpose / why

I think we should encourage people to change the COMPOSE_PROJECT_NAME variable when setting up a new install. If they don't change it now, it's harder to change later if they decide to run multiple instances. Also, by leaving it set to isle-dc we increase the risk of accidentally overwriting the existing containers when spinning up another set of isle-dc containers.

## Interested Parties

@islandora/documentation

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
