### PR TITLE
Correct the admin URL

### DIFF
--- a/docs/user-documentation/advanced-search.md
+++ b/docs/user-documentation/advanced-search.md
@@ -51,7 +51,7 @@ drush en islandora_advanced_search
 ## Configuration
 
 You can set the following configuration at **Administration** >> **Configuration** >> **Advanced Search Settings**
-(admin/config/islandora/advanced_search):
+(admin/config/search/advanced):
 
 ![screenshot of the advanced search setting page](../assets/islandora_advanced_search_settings.png)
 

--- a/docs/user-documentation/advanced-search.md
+++ b/docs/user-documentation/advanced-search.md
@@ -70,7 +70,7 @@ hierarchy of `field_member_of` for each repository item.
 Add a new `Content` solr field `field_descendant_of` to the solr index at
 `admin/config/search/search-api/index/default_solr_index/fields`.
 
-![screenshot of field_decent_of](../assets/advanced_search_field_descendant_of.png)
+![screenshot of field_decent_of](../assets/advanced_search_field_decedent_of.png)
 
 Then under `admin/config/search/search-api/index/default_solr_index/processors`
 enable `Index hierarchy` and setup the new field to index the hierarchy.


### PR DESCRIPTION
## Purpose / why
Fix wrong URL & corrected image URL

## What changes were made?

Points to admin/config/search/advanced 

## Verification
Try to go to admin/config/islandora/advanced_search (error 404), now go to admin/config/search/advanced and the page should load just fine.

Also the image now loads.

## Interested Parties

@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)? N/A
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
