### PR TITLE
Add warning that facets arent searchable.

### DIFF
--- a/docs/user-documentation/facet_on_vocabulary_reference_fields.md
+++ b/docs/user-documentation/facet_on_vocabulary_reference_fields.md
@@ -61,3 +61,9 @@ This step adds the facets in a single block.
 1. Click **Save**.
 
 At this point, searching for content that has facet values should cause the block to appear. For more in-depth overview of search, see [Configure Advanced Search](advanced-search.md)
+
+!!! note "Facets aren't necessarily searchable" 
+    While this will create facets, the values that appear won't work (won't necessarily bring back any content) if you type them in the search box. This is because the fulltext search box uses only fulltext fields, and facets, as mentioned above, requires string fields. 
+    
+    If you want to be able to search for taxonomy term values and bring up the related nodes, you could either include the full rendered item for your content type, or you may wish to repeat step 2 for each entity reference field, and set the new fields to fulltext so that searching for term values brings back node results. 
+

--- a/docs/user-documentation/facet_on_vocabulary_reference_fields.md
+++ b/docs/user-documentation/facet_on_vocabulary_reference_fields.md
@@ -25,7 +25,7 @@ Steps 1 and 2 add the field to the Solr index.
    1. Click on the **+** next to "Taxonomy term". A bunch of subfields will appear.     
    1. Look for the field that contains "YOUR_FIELD:entity:name" and click on the "Add" button at the end of the bulleted point.
    1. Click “Done.”
-1. Find your newly added fields In the list, change the "Type" of the new field to "string" if needed
+1. Find your newly added fields In the list, and ensure the "Type" of the new field is "string" so it can be compatible with Facets.  
 1. If the "Machine name" of the new field is generic, like "name_1", change it to be the same as the part of the "Property path" up to the first : (this will be the same as the field's machine name).
 1. Click on the **Save changes** button.
 


### PR DESCRIPTION
## Purpose / why

In testing https://github.com/Islandora/documentation/pull/1997, I noticed that I could get facets, but that they didn't work as keyword terms when I typed them in the search box. So I made a little blurb that the values dont work unless they also repeat adding fields, and make them full text. 

## What changes were made?

Slight variation in the Step 2 description, and a hopefully-not-overly-wordy note block  at the end. 

## Verification

Does it read okay, communicate something sensibly, and can you verify? (I wrote this to describe my experience using the playbook's standard profile install, and it "worked for me")

## Interested Parties


@manez , @Islandora/8-x-committers_

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
