### PR TITLE
Add navigation link to current and future release notes.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,9 @@ nav:
       # particular recipe. The ISLE documentation page was written with a
       # 'non-technical' user in mind who wants to test. The Manual installation
       # guides mention that users will need additional knowledge about server administration.
+      - 'Release Notes':
+          - '8.x-2.0 Release Notes': 'release_notes/8.x-2.0.md'
+          - 'Older Release Notes': 'https://github.com/Islandora/documentation/tree/main/docs/release_notes'
       - 'Docker (ISLE)':
           - 'Introduction to ISLE': 'installation/docker-introduction.md'
           - 'Prerequisites': 'installation/docker-prereq.md'


### PR DESCRIPTION
## Purpose / why

From issue #2063

The official docs site lacked a link in the navigation to the current (and only)[ Islandora release notes](https://github.com/Islandora/documentation/blob/main/docs/release_notes/8.x-2.0.md). 


## What changes were made?

A link was added to the navigation to the current release notes, and a [link](https://github.com/Islandora/documentation/tree/main/docs/release_notes) was added that will in the future will list past release notes.

## Verification

Build the mkdocs and verify the links behave correctly and are accurate.

## Interested Parties

@Islandora/documentation 

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
