### PR TITLE
URL for drupal.yml was broken due to branch name change

### DIFF
--- a/docs/technical-documentation/install-enable-drupal-modules.md
+++ b/docs/technical-documentation/install-enable-drupal-modules.md
@@ -10,7 +10,7 @@ $ composer require "<vendor>/<package>:<version>"
 $ composer require "islandora/islandora_defaults:1.0.0"
 ```
 
-In the [Islandora 8 playbook](https://github.com/Islandora-Devops/claw-playbook), you can add a Drupal module's or theme's machine name to the `drupal_composer_dependencies` variable [here](https://github.com/Islandora-Devops/islandora-playbook/blob/main/inventory/vagrant/group_vars/webserver/drupal.yml).
+In the [Islandora 8 playbook](https://github.com/Islandora-Devops/islandora-playbook), you can add a Drupal module's or theme's machine name to the `drupal_composer_dependencies` variable [here](https://github.com/Islandora-Devops/islandora-playbook/blob/dev/inventory/vagrant/group_vars/webserver/drupal.yml).
 To enable the Drupal module or theme, add the module machine name to the `drupal_enable_modules` variable as well.
 
 ![alt text](../assets/install-enable-drupal-modules_drupal_composer_dependencies.png?raw=true "drupal_composer_dependencies Screenshot")


### PR DESCRIPTION
404 on https://islandora.github.io/documentation/technical-documentation/install-enable-drupal-modules/

The default branch changed from main to dev at some point.

Also updated the link to islandora-playbook repo so users don't have to go through a redirect.

## Purpose / why

Broken URL

## What changes were made?

Updated 2 url's

## Verification

Click the URL's do you end up either at a 404, or the page expected?

## Interested Parties
@islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)? No, there was no issue for this, just a PR.
* [X] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [X] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
