### PR TITLE
Fix Links to Islandora.ca site that broke after site redesign

### DIFF
--- a/docs/contributing/readme_template.md
+++ b/docs/contributing/readme_template.md
@@ -78,7 +78,7 @@ This project has been sponsored by:
 
 If you would like to contribute, please get involved by attending our weekly [Tech Call](https://github.com/Islandora/documentation/wiki). We love to hear from you!
 
-If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.
+If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](https://drive.google.com/file/d/1k6eCM5EV-w4I4ErkiGj4NJwvLnXkejyk/view?usp=sharing) or [Corporate Contributor License Agreement](https://drive.google.com/file/d/1-SQYuHWRxvltQYgkFWpYv7nGbvJp1u8h/view?usp=sharing). Please see the [Contributors](https://github.com/Islandora/islandora-community/wiki/Onboarding-Checklist) pages on Islandora.ca for more information.
 
 We recommend using the [islandora-playbook](https://github.com/Islandora-Devops/islandora-playbook) to get started.  If you want to pull down the submodules for development, don't forget to run git submodule update --init --recursive after cloning.
 

--- a/docs/installation/docker-demo.md
+++ b/docs/installation/docker-demo.md
@@ -1,6 +1,6 @@
 # Installing a Demo Server
 
-Using ISLE, you can spin up a repository that is exactly like future.islandora.ca, including the sample content. If you want to kick the tires and see what Islandora can do with the minimal amount of setup, this is for you.
+Using ISLE, you can spin up a repository that is exactly like sandbox.islandora.ca, including the sample content. If you want to kick the tires and see what Islandora can do with the minimal amount of setup, this is for you.
 
 !!! Warning "Demonstration Purposes Only!"
     Please be advised, the environment you are about to create is meant to be temporary. The drupal codebase is baked into a container and is ephemeral.  If you [install new modules](../docker-maintain-drupal/), they will be gone if your drupal container goes down for any reason.

--- a/docs/placeholder.md
+++ b/docs/placeholder.md
@@ -1,8 +1,8 @@
 # Placeholder page
 This page serves as a placeholder for functionality that still needs documentation.
 
-Interested in contributing to the Islandora 8 documentation? Join the Community!
-The [Islandora community](https://islandora.ca/index.php/community) is an active group of users, managers, librarians, documenters, and developers from GLAM (and beyond!) institutions worldwide. We welcome discussion and contribution through various mailing lists, channels, interest groups, and calls. The Islandora community operates under the [Islandora Code Of Conduct](https://islandora.ca/codeofconduct). See our [Contributing Guidelines](contributing/CONTRIBUTING.md) for more information, or drop by a meeting of the [Documentation Interest Group](https://github.com/islandora-interest-groups/Islandora-Documentation-Interest-Group) for a helping hand.
+Interested in contributing to the Islandora documentation? Join the Community!
+The [Islandora community](https://www.islandora.ca/community) is an active group of users, managers, librarians, documenters, and developers from GLAM (and beyond!) institutions worldwide. We welcome discussion and contribution through various mailing lists, channels, interest groups, and calls. The Islandora community operates under the [Islandora Code Of Conduct](https://islandora.ca/codeofconduct). See our [Contributing Guidelines](contributing/CONTRIBUTING.md) for more information, or drop by a meeting of the [Documentation Interest Group](https://github.com/islandora-interest-groups/Islandora-Documentation-Interest-Group) for a helping hand.
 
 
 !!! note "Documentation for previous versions"

--- a/docs/user-documentation/users.md
+++ b/docs/user-documentation/users.md
@@ -18,7 +18,7 @@ Additional user roles can be created and assigned customized permissions, as des
 ## Before you start
 
 - This How-To assumes a very basic familiarity with Drupal.
-- This How-To is generally appliable for any Islandora site, but the examples given are taken from an Islandora demo using the (optional) **[Islandora Defaults](https://github.com/Islandora/islandora_defaults)** configuration. This configuration is deployed automatically if you build your Islandora site using the [Ansible Playbook](/installation/playbook), [ISLE with Docker-Compose](/installation/docker-compose), or are using the [sandbox or a Virtual Machine Image](https://islandora.ca/try).
+- This How-To is generally appliable for any Islandora site, but the examples given are taken from an Islandora demo using the (optional) **[Islandora Defaults](https://github.com/Islandora/islandora_defaults)** configuration. This configuration is deployed automatically if you build your Islandora site using the [Ansible Playbook](/installation/playbook), [ISLE with Docker-Compose](/installation/docker-compose), or are using the [sandbox or a Virtual Machine Image](https://www.islandora.ca/get-islandora).
 
 ## How to Add a User
 1. Log in to Drupal. You will need the _Administrator_ role to manage users.


### PR DESCRIPTION
## Purpose / why

Fix some broken links after redesign of islandora.ca site

## What changes were made?

Updated links to new pages.

## Verification

## Interested Parties
@Islandora/documentation

---

## Checklist

* [x] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [x] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [x] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [x] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
