### PR TITLE
Add webinar to video docs

### DIFF
--- a/docs/user-documentation/video-docs.md
+++ b/docs/user-documentation/video-docs.md
@@ -44,6 +44,7 @@ New videos are added to [the playlist](https://www.youtube.com/playlist?list=PL4
 - [Advanced Views](https://youtu.be/inPRZeQGnKI): How to bring together several settings and tools to make a more advanced image view.
 - [Batch Editing](https://youtu.be/ZMp0lPelOZw): How to use Views Bulk Edit to create a batch editing view for Islandora.
 - [Export and Import a View](https://youtu.be/0NXrzSzxhLc): How to copy a custom View from one Islandora site to another.
+- [Islandora Webinar: Islandora and Drupal Views](https://www.youtube.com/watch?v=VfuRHXFD89c): a 1-hour session on working with Views.
 
 ## Additional Topics
 


### PR DESCRIPTION
## Purpose / why

There's a great webinar that isn't linked anywhere in the docs.

## What changes were made?

Added a link

## Verification

Is this a good addition?

## Interested Parties


@Islandora/documentation, 

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
