### PR TITLE
Update the reference to the committers group

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Interested Parties
 
 
-> _**Replace this text** - Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/8-x-committers_
+> _**Replace this text** - Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/committers_
 
 ---
 

--- a/docs/contributing/contributing-workflow.md
+++ b/docs/contributing/contributing-workflow.md
@@ -33,12 +33,12 @@ We operate under the [Islandora Community Code of Conduct](https://www.islandora
   - If there is an urgent need for the pull request to be addressed quickly, indicate the need in the pull request template or a comment.
   - Complexity should also be taken into account when evaluating how quickly to merge a pull request. Changes that affect core modules or make extensive changes should receive more review and testing.
 - All interested parties should be satisfied before something is merged; no hard numbers. If you know who is likely to be interested, tag them. Tag the creator of the issue if possible. Make a reasonable effort.
-- If a pull request languishes without response when one is needed, tag @Islandora/8-x-committers (or @Islandora-Devops/committers if you’re working on install code) with a reminder and/or put the issue on the agenda for the next Islandora 8 Tech Call
+- If a pull request languishes without response when one is needed, tag @Islandora/committers (or @Islandora-Devops/committers if you’re working on install code) with a reminder and/or put the issue on the agenda for the next Islandora 8 Tech Call
 - All contributions to GitHub must be accompanied by either an Individual Contributor License or a Corporate Contributor License covering the contributor.
 
 #### Development Workflow:
 - Create a Github Issue if none exists
-  - Assign the issue to yourself or request it to be assigned in a comment on the issue.  Be sure to tag @Islandora/8-x-committers to bring attention to it.
+  - Assign the issue to yourself or request it to be assigned in a comment on the issue.  Be sure to tag @Islandora/committers to bring attention to it.
 - Perform development on a ‘feature’ branch.  Give your branch a name that describes the issue or feature.  Using something like ‘issue-xxx‘ and including the issue number is always a safe bet if you don’t know what to name it. 
 - When the code is ready for review, issue a pull request on Github from your feature branch into the development branch (‘8.x-1.x’ for Drupal modules and ‘dev’ for everything else)
 - Continuous integration checks need to be satisfied before the code can be merged

--- a/docs/contributing/editing-docs.md
+++ b/docs/contributing/editing-docs.md
@@ -39,7 +39,7 @@ If you _are_ a member of the Islandora GitHub organization, you will be able to 
 ![start a new branch and PR](../assets/editing-docs-branch.png)
 
 - You will be taken to the [pull request template](https://github.com/Islandora/documentation/blob/main/.github/PULL_REQUEST_TEMPLATE.md) which will prompt you to fill out some basic information about what you have changed, and why. Replace all relevant instances of _Replace this text_ with your own text.
-    - You will have the option to tag _Interested Parties_, or people you would like to review your work, by writing in their GitHub account name after the `@` symbol. If you don't have anyone specific in mind, you may tag `@Islandora/8-x-committers` to alert all Islandora 8 Committers that there is a new pull request for their review.
+    - You will have the option to tag _Interested Parties_, or people you would like to review your work, by writing in their GitHub account name after the `@` symbol. If you don't have anyone specific in mind, you may tag `@Islandora/committers` to alert all Islandora 8 Committers that there is a new pull request for their review.
 
 ![start a new branch and PR](../assets/editing-docs-PR.png)
 


### PR DESCRIPTION
## Purpose / why
Update reference to committers group

## What changes were made?

@Islandora/8-x-committers references changed to @Islandora/committers

## Verification



## Interested Parties

@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [X] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [X] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [X] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
