### PR TITLE
Small update to bug_report.md to suggest checking issue queue first

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,14 @@ assignees: ''
 <!--
 
 Thank you for reporting your bug to islandora! 
+
+Please check our bug reporting guidelines here:
 https://islandora.github.io/documentation/contributing/CONTRIBUTING/#report-a-bug
+
+We recommend that you search the Islandora issue queue for existing issues (aka tickets) that already describe the problem you have encountered; if there is such a ticket please add your information as a comment instead of creating a new issue.
+
+Islandora issue queue: 
+https://github.com/Islandora/documentation/issues
 
 -->
 


### PR DESCRIPTION
## Purpose / why

To try to encourage those about to create a new issue to check the issue to queue to see if their issue has been reported already. 

## What changes were made?

Added a couple of sentences and a link.

## Verification


## Interested Parties

@Islandora/committers


---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
