### PR TITLE
Remove use of "-T" for docker-compose exec interactive use

### DIFF
--- a/docs/installation/docker-maintain-drupal.md
+++ b/docs/installation/docker-maintain-drupal.md
@@ -20,11 +20,11 @@ docker-compose exec -T drupal with-contenv bash -lc 'YOUR COMMAND'
 
 You can also just shell into the drupal container and run commands as well,
 just be aware that if you cycle your container for any reason, you'll lose your
-bash history.  If you want to shell in to run commands, drop the `-lc 'YOUR COMMAND'`
-bit.
+bash history.  If you want to shell in to run commands, drop the `-T` and `-lc 'YOUR COMMAND'`
+bits.
 
 ```
-docker-compose exec -T drupal with-contenv bash
+docker-compose exec drupal with-contenv bash
 ```
 
 ## Updating your Drupal Site


### PR DESCRIPTION
## Purpose / why
I was doing some testing and noticed that line 27 in `docker-maintain-drupal.md` is using the `-T` flag for `docker-compose exec` which would not allow for interactive shell use as expected.

From the man page...
```
Usage:  docker compose exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]
...
  -T, --no-TTY docker compose exec   Disable pseudo-TTY allocation. By default docker compose exec allocates a TTY.
...
```
Seem that on the other examples of `docker-compose exec -T...` are fine on the rest of the page, since they are executing non-interactive/specific shell commands.

## What changes were made?
In line 27 I removed use of the "-T" flag, and a few lines before suggested that this flag be removed for interactive use.

## Verification

Run `docker-compose exec drupal with-contenv bash` and watch it trigger an interactive shell.

Then run `docker-compose exec drupal with-contenv bash` and watch the terminal hang waiting for bash to exit.


## Interested Parties


@Islandora/documentation
@Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
