### PR TITLE
Extend mac permissions warning and re-order steps

### DIFF
--- a/docs/installation/install-a-demo.md
+++ b/docs/installation/install-a-demo.md
@@ -70,7 +70,8 @@ in order to install the local certificate.
 
 _**Note for Mac users:**_ If when executing the script, you are shown a pop-up warning
 that "setup.command cannot be opened", please navigate to _System Preferences >
-Security and Privacy_. Here, you can click "Allow anyway" to allow the script to run.
+Security and Privacy_. Here, you can click "Allow anyway" and then re-try running
+the script. This may need to be done more than once.
 
 Create Stack
 --------------------------------------------------------------
@@ -84,8 +85,8 @@ Desktop Dashboard.
 4. Open the sidebar.
 5. Click on **Stacks**.
 6. Click **Add Stack**.
-7. Select **Upload from your Computer**.
-8. Type in the name **sandbox** (_lowercase_).
+7. Type in the name **sandbox** (_lowercase_).
+8. Select **Upload from your Computer**.
 9. Upload the **docker-compose.yml** file you generated via the setup script.
 10. Click on **Deploy the Stack**. The button will then display _Deployment in progress_  - do not click away while this message is shown.
 
@@ -130,8 +131,8 @@ The login credentials can be found
 Reinstall
 ==============================================================
 
-If you want to re-install **Islandora Sandbox**, and restore it to a known good
-state. Please perform the following steps:
+If you want to re-install **Islandora Sandbox**, and restore it to its original
+state., please perform the following steps:
 
 1. Open Docker Desktop.
 2. Click on Portainer.

--- a/docs/installation/install-a-demo.md
+++ b/docs/installation/install-a-demo.md
@@ -3,7 +3,7 @@
 This demo, available to download [here](https://drive.google.com/file/d/1mA3sLIoqYlSlUgvJ0N05NpCQJ0nW6N1m/view?usp=sharing), is loaded with sample content and configurations to demonstrate
 features of Islandora and provide a starting point for exploration. 
 
-Download [this file](https://drive.google.com/file/d/1mA3sLIoqYlSlUgvJ0N05NpCQJ0nW6N1m/view?usp=sharing), and open and follow the instructions in the README.md.html file (also shown below). Thanks, and happy building!
+Download [this file](https://drive.google.com/file/d/1mA3sLIoqYlSlUgvJ0N05NpCQJ0nW6N1m/view?usp=sharing), and open and follow the instructions in the README.md.html file (also shown below). It is recommended that you have a minimum of 4GB of space available on your machine before getting started. Thanks, and happy building!
 
 
 Requirements


### PR DESCRIPTION
## Purpose / why

- it wasn't clear how to continue after clicking "allow anyway" (you have to re-start the script, it seems, but it's worth clarifying that you have to do that
- i had to do that process twice, as there seemed to be multiple unknown developers. this might not have been apparent on a mac that was already familiar with this ecosystem. 
- steps 7 and 8 needed to be switched, as step 7 opens the file upload dialogue which is used in step 9, but step 8 requires that dialogue window to be closed so you can add a name.

## What changes were made?
- extended the note for mac users who have to allow an unknown software developer
- swapped steps in the stack instructions

## Verification
does this run? Does this make sense?

## Interested Parties

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
