### PR TITLE
Remove references to Carapace.

### DIFF
--- a/docs/contributing/releasing-islandora.md
+++ b/docs/contributing/releasing-islandora.md
@@ -119,10 +119,6 @@ Release the `jsonld` module by creating a new release for it in Github.
 
 Release the `openseadragon` module by creating a new release for it in Github.
 
-### Release Carapace
-
-Release the `carapace` theme by creating a new release for it in Github.
-
 ### Release migrate_islandora_csv
 
 Release the `migrate_islandora_csv` module by creating a new release for it in Github.

--- a/docs/installation/manual/configuring_drupal.md
+++ b/docs/installation/manual/configuring_drupal.md
@@ -102,10 +102,7 @@ Components we've now downloaded using `composer require` can be enabled simultan
 
 ```bash
 cd /opt/drupal
-drush -y en rdf responsive_image devel syslog serialization basic_auth rest restui search_api_solr facets content_browser pdf admin_toolbar islandora_defaults controlled_access_terms_defaults islandora_breadcrumbs islandora_iiif islandora_oaipmh
-# If Carapace was downloaded, now is the time to enable and set it as well.
-drush -y theme:enable carapace
-drush -y config-set system.theme default carapace
+drush -y en rdf responsive_image devel syslog serialization basic_auth rest restui search_api_solr facets content_browser pdf admin_toolbar controlled_access_terms_defaults islandora_breadcrumbs islandora_iiif islandora_oaipmh
 # After all of this, rebuild the cache.
 drush -y cr
 ```


### PR DESCRIPTION
## Purpose / why
Carapace has been deprecated.

## What changes were made?

Removes references to Carapace from:
* the release instructions
* the manual install instructions (which still need attention)
* also removed a stray `islandora_defaults` from there. 

## Verification

* do the docs still build and make sense? 
* Are there any other places where references should be removed?

## Interested Parties
<!-- Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/committers_ -->

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
