### PR TITLE
ACME External Account Binding Support (#2096)

### DIFF
--- a/docs/installation/docker-custom.md
+++ b/docs/installation/docker-custom.md
@@ -93,6 +93,27 @@ docker-compose restart traefik
 
     Please note that sometimes the upstream provider of the traefik.me certificate takes a couple of days to update the certificiate after it expires or is accidently revoked.
 
+### Requesting Certifcates through ACME and External Account Binding
+
+To request certificates through another Certificate Authority (CA) that supports External Accounting Binding through ACME such as InCommon or ZeroSSL you will need to add the following to your `.env` file:
+
+```
+USE_ACME=true
+ACME_EMAIL=your-email@example.org
+ACME_SERVER=
+ACME_EAB_KID=
+ACME_EAB_HMAC=
+```
+
+Where `ACME_SERVER` is the CA server to use, `ACME_EAB_KID` is the key identifer from the External CA, and `ACME_EAB_HMAC` is the HMAC key from the External CA.
+
+Once you have added these commands you will need to run the following commands:
+
+```
+make -B docker-compose.yml
+make up
+```
+
 ## Building and Deploying Your Custom Container
 
 First, set your `ENVIRONMENT` variable to `custom` in  your .env file in addition to the changes outlined above


### PR DESCRIPTION
Adds documentation on configuring Traefik for External Account Binding with ACME.

## Replaces #2096 which was merged too early.

## Purpose / why
Update Docs for ACME External Account Binding.

This can't be merged until https://github.com/Islandora-Devops/isle-dc/pull/253 is merged, otherwise the feature doesn't exist.

## What changes were made?
Add documentation for how to configure External Account Binding with ACME

## Verification

Utilize an SSL Certificate provide that supports External Account Binding to request SSL Certificate. Verify you get SSL certificate from your provider, and not Let's Encrypt. A couple of options include InCommon and ZeroSSL.com

<!-- > _**Replace this text** - Document the details that help a reviewer verify the documentation._ -->

## Interested Parties
@Islandora/documentation

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [X] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [X] Are the changes accurate, useful, free of typos, etc?

> __Person merging__ should ensure the following
* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?


## Related Tickets
https://github.com/Islandora-Devops/isle-dc/pull/253
https://github.com/Islandora-Devops/isle-dc/pull/252
https://github.com/Islandora/documentation/pull/2096