### PR TITLE
Remove m1 warning

### DIFF
--- a/docs/installation/docker-prereq.md
+++ b/docs/installation/docker-prereq.md
@@ -26,11 +26,6 @@ To see if you have Docker installed, type `docker --version` in a terminal.
 
 If you need to install Docker, we recommend using the application [Docker Desktop](https://www.docker.com/products/docker-desktop). It provides a GUI for managing Docker container in Windows and MacOS, along with the Docker engine and suite of command-line tools. Linux users don't get a desktop client, but can install the Engine and command-line tools the instructions [here](https://docs.docker.com/engine/install/).
 
-!!! Warning
-    There is an open issue with macOS M1 chip users upgrading to Docker Desktop version v4.16.2. Currently it is suggested that you don’t upgrade to version v4.16.2 until the Islandora community finds a fix.
-    For more details see the relevant issue: [https://github.com/Islandora-Devops/isle-dc/issues/323](https://github.com/Islandora-Devops/isle-dc/issues/323)
-
-
 !!! Warning "Memory, Processors, and Swap Requirements"
     To run ISLE on Docker Desktop, you must increase the resources allocated to the software. See Docker docs on [setting resources on Windows](https://docs.docker.com/docker-for-windows/#resources) (see note on how to allocate/restrict memory when using WSL 2) or [setting resources on Mac](https://docs.docker.com/docker-for-mac/#resources).
 

--- a/docs/installation/install-a-demo.md
+++ b/docs/installation/install-a-demo.md
@@ -29,11 +29,6 @@ For Windows 10, you may receive the "Docker Failed to Start" Error message. To r
 * Restart computer for all changes to take effect
 
 
-!!! Note
-    There is an open issue with macOS M1 chip users upgrading to Docker Desktop version v4.16.2. Currently it is suggested that you don’t upgrade to version v4.16.2 until the Islandora community finds a fix.
-    For more details see the relevant issue: [https://github.com/Islandora-Devops/isle-dc/issues/323](https://github.com/Islandora-Devops/isle-dc/issues/323)
-
-
 **If you already have Docker Desktop installed,** make sure that the **Extensions** 
 feature is listed in the left sidebar. If it is not, you need to update to the newest 
 version of Docker Desktop. This is required to add the Portainer extension.


### PR DESCRIPTION
## Purpose / why
<!-- Restate the purpose/justification of this work and include links to any Issues or other discussions that are related to this work. -->
I removed the M1 warning for Docker Desktop because it was reported to no longer be an issue. Big thanks to @ysuarez for catching that!

## What changes were made?
<!-- State clearly the direct additions or modifications made in this pull request. -->
The M1 warning for Docker Desktop has been removed in the install a demo and prerequisites pages.

## Verification
<!-- Document the details that help a reviewer verify the documentation. -->

## Interested Parties
<!-- Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/committers_ -->

* @ysuarez 
* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
