### PR TITLE
Update dev instructions to use starter site

### DIFF
--- a/docs/installation/docker-local.md
+++ b/docs/installation/docker-local.md
@@ -7,9 +7,9 @@ changes are automatically reflected on the Drupal container.
 ## Getting Started
 
 If you don't already have a Drupal site, you'll be given a basic setup using Drupal 9 and the
-[Islandora install profile](https://github.com/islandora-devops/islandora_profile).
+[Islandora Starter Site](https://github.com/Islandora-Devops/islandora-starter-site).
 
-If you do already have a Drupal 9 site, use git to clone it into place as the `codebase` folder.
+If you do already have a Drupal site, use git to clone it into place as the `codebase` folder.
 
 ```
 cd /path/to/isle-dc
@@ -21,11 +21,11 @@ your `.env` file. If you don't have one, copy over `sample.env` and name it `.en
 set
 
 ```
-ENVIRONMENT=local
+ENVIRONMENT=starter
 ```
 
 You should also change the `COMPOSE_PROJECT_NAME` variable. This determines the name of the
-Docker containers that are created when you run `make local`. If you leave this as the default
+Docker containers and volumes that are created when you run `make starter`. If you leave this as the default
 you will need to be careful not to overwrite the containers with another install of `isle-dc`
 later.
 ```
@@ -43,11 +43,11 @@ DRUPAL_INSTALL_PROFILE=minimal
 Once you are ready, run
 
 ```bash
-make local
+make starter
 ```
 
 to install the Drupal site in your `codebase` folder and spin up all the other containers with it.
 
 Enjoy your Islandora instance!  Check out the [basic usage documentation](../docker-basic-usage) to see
 all the endpoints that are available and how to do things like start and stop Islandora. Your passwords,
-including the Drupal admin password, can be found in the `secrets/live` directory after you run `make local`.
+including the Drupal admin password, can be found in the `secrets/live` directory after you run `make starter`.


### PR DESCRIPTION
Instead of make local, recommend that we use make starter for dev installs

## Purpose / why
Starter seems to be the recommended way to install now, and is easier to work with for new installs

## What changes were made?
install instructions changed from make local to make starter

## Verification
Create a new site with `make starter` as described in the changed documentation.

Note: `make starter` does not currently allow installing from an existing codebase without a few extra steps not described here, but I have a PR (https://github.com/Islandora-Devops/isle-dc/pull/336) that will allow it to. If necessary I can update these docs to include the extra steps, but ideally that PR would go through first so that won't be necessary.

## Interested Parties
* @Islandora/documentation

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
