### PR TITLE
Create isle-installation-option-comparison.md

### DIFF
--- a/docs/installation/isle-installation-option-comparison.md
+++ b/docs/installation/isle-installation-option-comparison.md
@@ -1,0 +1,5 @@
+# ISLE Installation Option Comparison
+
+**Coming Soon!**
+
+This is a stub that will hold a chart of ISLE installation options.

--- a/docs/installation/isle-installation-option-comparison.md
+++ b/docs/installation/isle-installation-option-comparison.md
@@ -1,5 +1,32 @@
 # ISLE Installation Option Comparison
 
-**Coming Soon!**
+## Make Local
+* Creates a development environment
+* Codebase folder is bind-mounted
+* Uses the Islandora Sandbox repo to set up the Drupal site
+* Using git clone to create codebase folder
 
-This is a stub that will hold a chart of ISLE installation options.
+## Make Demo
+* Runs make local, then also populates the site with some demo content
+
+## Make Starter
+* Creates a development environment
+* Codebase folder is bind-mounted
+* Uses the Islandora Starter Site repo to set up the Drupal site
+* Using composer create project to create codebase folder
+* Can also be used with a custom codebase folder to spin up a production site from your already existing site instead of the starter site
+* If you place your codebase folder in the isle-dc directory it will use that, otherwise it downloads the starter site
+
+## Make Starter-dev
+* Creates a development environment
+* Codebase folder is bind-mounted
+* Uses the Islandora starter site repo to set up the drupal site
+* Using git clone to create codebase folder
+
+##  Make Production
+* Creates a production environment
+* Codebase folder is NOT bind-mounted
+* Uses a custom Drupal image to set up the drupal site
+* Using composer install on the composer.json file that is included in the custom Drupal container
+
+make local and make starter-dev both leave you with a git repo in your codebase folder, so you could easily contribute back to the sandbox or starter site. Running make starter uses composer instead so the codebase folder is not set up as a git repo. I believe the only reason to use starter-dev is if you are contributing to the starter site. Otherwise make starter will create a new site or spin up an existing one for you.


### PR DESCRIPTION
Add a page for ian nstallation option comparison chart

## Purpose / why
We now have at least five options for creating a site using make. We need a place where users can compare them directly

## What changes were made?
We are adding a new page.

## Verification
This is a stub that needs work.

## Interested Parties

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
