### PR TITLE
Update content_types.md

### DIFF
--- a/docs/user-documentation/content_types.md
+++ b/docs/user-documentation/content_types.md
@@ -93,15 +93,11 @@ In the Admin menu, return to **Structure** >> **Content Types** and find the _Re
 
 To create your own custom content type from scratch, please refer to [this guide](https://www.drupal.org/docs/8/administering-drupal-8-site/managing-content-0/create-a-custom-content-type) on Drupal.org.
 
-Custom content types are not synced to Fedora or indexed by the triple-store by default. Repository managers must add them to a context that instructs Drupal to perform these synchronizations. In the Islandora Starter Site, the "Content" ('repository_content') context does this. To add a new content type to that context:
+Your custom content types can contain whatever fields you like, but there are two mandatory fields that all Islandora content types should contain:
 
-1. Navigate to the _Contexts_ configuration page ('/admin/structure/context').
-1. Find the _Content_ context and click the corresponding **Edit** button ('/admin/structure/context/repository_content').
-1. Find the _Node Bundle_ condition in the _Conditions_ section.
-1. Click the checkbox for the new Content Type.
-1. Scroll down to the bottom of the page and click **Save and continue**.
+1. In order for a custom content type to be considered an Islandora Object, it needs to have the field "Member of" ('field_member_of'). This allows it to be included in contexts that have the "Node is an Islandora node" condition. Nodes that have this field will automatically be synced to Fedora and indexed by the triple store if you are using the context provided by the Islandora Starter Site. This field is also what allows a node to have media associated with it and to have children nodes.
 
-Updating contexts does not retroactively fire any actions. Any of the custom content type's nodes that were created before updating the context will need to have the indexing action manually triggered.
+2. The other mandatory field is "Model" ('field_model'). This is used in several of the contexts that the Islandora Starter Site provides. This field determines how Islandora objects are diplayed, and how media derivatives are created.
 
 ## Updating and creating an RDF Mapping
 

--- a/docs/user-documentation/content_types.md
+++ b/docs/user-documentation/content_types.md
@@ -95,7 +95,7 @@ To create your own custom content type from scratch, please refer to [this guide
 
 Your custom content types can contain whatever fields you like, but there are two mandatory fields that all Islandora content types should contain:
 
-1. In order for a custom content type to be considered an Islandora Object, it needs to have the field "Member of" ('field_member_of'). This allows it to be included in contexts that have the "Node is an Islandora node" condition. Nodes that have this field will automatically be synced to Fedora and indexed by the triple store if you are using the context provided by the Islandora Starter Site. This field is also what allows a node to have media associated with it and to have children nodes.
+1. In order for a custom content type to be considered an Islandora Object, it needs to have the field "Member of" ('field_member_of'). This allows it to be included in contexts that have the "Node is an Islandora node" condition. Nodes that have this field will automatically be synced to Fedora and indexed by the triple store if you are using the context provided by the Islandora Starter Site. Having this field present in your content type also gives you tabs for adding children and media when viewing an item of that content type.
 
 2. The other mandatory field is "Model" ('field_model'). This is used in several of the contexts that the Islandora Starter Site provides. This field determines how Islandora objects are diplayed, and how media derivatives are created.
 


### PR DESCRIPTION
Updated instructions for new content types to include mandatory fields and to remove steps that are no longer necessary.

## Purpose / why
It was not clear to me that the member of field was mandatory, but without it the nodes are not considered Islandora objects.

## What changes were made?
Added info on mandatory fields (model and member of) to make it clear that both of those fields need to be included in any custom content types.

Also removed instructions for updating context that is no longer needed. Indexing happens on all nodes that are considered Islandora objects, and as long as they have the member of field they will be considered islandora objects.

## Verification
Create a new content type with the member of field included. Add an object using that content type. Check that the object is in Fedora.

## Interested Parties

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
