### PR TITLE
add note about views bulk operations

### DIFF
--- a/docs/installation/docker-available-commands.md
+++ b/docs/installation/docker-available-commands.md
@@ -40,11 +40,11 @@ There's a lot of useful commands available to you from within the `isle-dc` fold
 
 ## Reindex Fedora Metadata
 
-`make reindex-fcrepo-metadata` will reindex RDF metadata from Drupal into Fedora.
+`make reindex-fcrepo-metadata` will reindex RDF metadata from Drupal into Fedora. Requires the [Views Bulk Operations Module](https://www.drupal.org/project/views_bulk_operations).
 
 ## Reindex Solr
 `make reindex-solr` will rebuild rebuild Solr search index for your repository.
 
 ## Reindex the Triplestore
 
-`make reindex-triplestore` will reindex RDF metadata from Drupal into Blazegraph.
+`make reindex-triplestore` will reindex RDF metadata from Drupal into Blazegraph. Requires the [Views Bulk Operations Module](https://www.drupal.org/project/views_bulk_operations).


### PR DESCRIPTION
## Purpose / why
Make commands for reindexing fedora and blazegraph require views bulk operations module, so this documents that.

## What changes were made?
Added note about views operations module to page of make commands

## Verification
try to reindex fedora or triplestore with and without views bulk operations module

## Interested Parties
* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
