### PR TITLE
Update committers list & add link to wiki

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -32,7 +32,6 @@ The following is an alphabetized list of the current Islandora committers:
 | Melissa Anez                | LYRASIS                               | manez          |
 | Bryan Brown                 | Florida State University              | bryjbrown      |
 | Jordan Dukart               | discoverygarden                       | jordandukart   |
-| Debbie Flitner              | Arizona State University              | dflitner       |
 | Willow Gillingham           | Born-Digital                          | wgilling       |
 | Jonathan Hunt               | Catalyst.Net                          | kayakr         |
 | Mark Jordan                 | Simon Fraser University               | mjordan        |
@@ -46,9 +45,9 @@ The following is an alphabetized list of the current Islandora committers:
 | Bethany Seeger              | Johns Hopkins University              | bseeger        |
 | Seth Shaw                   | University of Nevada, Las Vegas       | seth-shaw-unlv |
 | Alan Stanley                | Agile Humanities                      | ajstanley      |
+| Yamil Suarez                | Berklee College of Music              | ysuarez        |
 | Adam Vessey                 | discoverygarden                       | adam-vessey    |
 | Jared Whiklo                | University of Manitoba                | whikloj        |
-| Yamil Suarez                | Berklee College of Music              | ysuarez        |
 
 
 ## Emeritus Committers
@@ -57,12 +56,15 @@ The following is an alphabetized list of the prior Islandora committers:
 
 | Name                        | Organization                      |
 |-----------------------------|-----------------------------------|
+| Daniel Aitken               | discoverygarden                   |
 | Aaron Coburn                | Amherst College                   |
+| Jonathan Green              | LYRASIS                           |
+| Debbie Flitner              | Arizona State University          |
 | Diego Pino                  | METRO                             |
 | Nick Ruest                  | York University                   |
 | Eli Zoller                  | Arizona State University          |
-| Daniel Aitken               | discoverygarden                   |
-| Jonathan Green              | LYRASIS                           |
+
+
 
 ## How are you evaluated as a potential committer? 
 
@@ -116,4 +118,4 @@ Checklist for a new committer (can be completed by sponsor or designate):
 * Add to islandora-committers google group.
  Announce the new committer ([template/committerAnnounce.txt](https://raw.githubusercontent.com/Islandora/documentation/main/docs/contributing/templates/committerAnnounce.txt)).
 
-
+For additional information about committers, visit [this Islandora community wiki page](https://github.com/Islandora/islandora-community/wiki/Islandora-Committers).


### PR DESCRIPTION
## Purpose / why
There are currently two lists of committers and emeritus committers:
https://islandora.github.io/documentation/contributing/committers
https://github.com/Islandora/islandora-community/wiki/Islandora-Committers  
 
This PR is an attempt to end up with a single list, which would be easier to maintain.


## What changes were made?

- I made sure that the github.io version of the lists had the same information as the wiki version of the lists.
- I also added a link to the wiki committers page.
- I made one committer an emeritus committer, as alerted by @seth-shaw-asu (Debbie Flitner)
- I again alphabetized both lists

## Verification


## Interested Parties

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
