### PR TITLE
added matomo upgrade instructions

### DIFF
--- a/docs/installation/docker-maintain-isle.md
+++ b/docs/installation/docker-maintain-isle.md
@@ -106,11 +106,44 @@ You can run this from your isle directory with
 docker compose exec mariadb mariadb-upgrade
 ```
 
+#### Matomo
+
+Matomo needs it's volume recreated when upgrading to a new version. The only file that needs to be preserved is /var/www/matomo/config/config.ini.php, so you should be able to recreate the volume with the following commands:
+
+Copy the config file from the container to your local machine
+```
+docker compose cp matomo:/var/www/matomo/config/config.ini.php .
+```
+
+Stop your containers and delete the Matomo volume. Replace {COMPOSE_PROJECT_NAME} with the value of that variable in your .env file. You can also find the volume name by running `docker volume ls`
+```
+make down
+docker volume rm {COMPOSE_PROJECT_NAME}_matomo-config-data
+```
+
+Start you containers to recreate the Matomo volume
+```
+make up
+```
+
+Copy the config file back into your new volume and set it's ownership to nginx
+```
+docker compose cp config.ini.php matomo:/var/www/matomo/config/
+docker compose exec matomo chown nginx:nginx /var/www/matomo/config/config.ini.php
+```
+
+Restart your Matomo container
+```
+docker compose restart matomo
+```
+
+Log in to your Matomo dashboard and check if you database needs updates. If so, follow the instructions on screen to update it.
+
 ### Specific Update Notes
 
 #### Version 1.x to 2.x
 
 Upgrading ISLE from 1.x to the next major version requires the TAG be set to 2.0.5 or higher. Once you create your containers 
-you will need to follow the above instructions for Mariadb, Solr, and Drupal.
+you will need to follow the above instructions for Mariadb, Solr, Matomo, and Drupal.
 
 ISLE 2.0 bumps PHP up to version 8.1, which allows you to upgrade to Drupal 10.


### PR DESCRIPTION
Added instructions on how to recreate the matomo volume in order to update to a new version of Matomo

## Purpose / why
Upgrading from buildkit 1.x to 2.x requires updating matomo

## What changes were made?
instructions added

## Verification
1. Create a site using TAG 1.0.10
2. Set Matomo to track site visits so that you get some data in your Matomo database
3. upgrade to TAG 2.0.10
4. Follow these instructions to update Matomo to 4.15.1
5. Check that site data is still available and that new site visits are tracked

## Interested Parties
https://github.com/Islandora-Devops/isle-dc/issues/356 
* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
