### PR TITLE
Add "ingredient" for Mathjax to Cookbook

### DIFF
--- a/docs/user-documentation/extending.md
+++ b/docs/user-documentation/extending.md
@@ -81,6 +81,14 @@ This repository is also a Drupal Feature that, when enabled as a module, will cr
 
 Command-line tool for ingesting (and updating) nodes and media from anywhere - you don't need to access to the Drupal server's command line. Provides robust data validation, flexible organization of your input data (can use CSV, Google Sheets, or Excel files) plus creation of taxonomy terms on the fly.
 
+### Richer Content
+
+#### Displaying equations and formulae
+
+[MathJax](https://www.drupal.org/project/mathjax)
+
+This module is a plug-and-play solution for rendering [LaTeX](https://www.latex-project.org/). It uses a CDN so no library has to be installed on your system, and the processing is done in the user's browser. In terms of Drupal, it provides a text filter that must be enabled in at least one text format (such as Full HTML). With this you can enter mathematical formulae in abstracts! Need to recognize unfamiliar symbols? Try this [LaTeX symbol reference](https://oeis.org/wiki/List_of_LaTeX_mathematical_symbols) thanks to the On-Line Encyclopedia of Integer Sequences.
+
 ### Search
 
 #### Custom search weighting


### PR DESCRIPTION
## Purpose / why

From the [MIG](https://github.com/islandora-interest-groups/Islandora-Metadata-Interest-Group/blob/main/Meetings/2024/2024-08-12.md), we want to be able to render equations but maybe not put it in the starter site since it's a little IR specific. 

## What changes were made?

Reference to the mathjax module.

## Verification
Does it read ok? Are the links working? Have you used it before and do you want to add anything?

## Interested Parties
<!-- Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/committers_ -->

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
