### PR TITLE
added instructions to disable fedora

### DIFF
--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -46,3 +46,24 @@ If you are removing a container which is referenced by Drupal, ensure that you u
 
 After doing `docker compose down`, run `docker compose up -d --remove-orphans` to remove the containers you removed from the docker-compose.yml file. 
 
+## Hiding Fedora From the Public
+
+By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN}`. If you do not want to expose your Fedora, you can stop this URL from working by disabling it via Traefik in your `docker-compose.yml`. To do this, you need to add the `traefik-disable` label to fcrepo-prod like this,
+
+```
+    fcrepo-prod:
+        <<: [*prod, *fcrepo]
+        environment:
+            <<: [*fcrepo-environment]
+            FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://${DOMAIN}/"
+        labels:
+            <<: [*traefik-disable, *fcrepo-labels]
+```
+
+If you have done this, you can also remove the DNS records that point this URL to your prodcution server.
+
+Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.ym'` in the `environment` section for `drupal-prod`, and should be changed to:
+
+```
+DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"
+```

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -62,7 +62,7 @@ By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN
 
 If you have done this, you can also remove the DNS records that point this URL to your prodcution server.
 
-Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.ym'` in the `environment` section for `drupal-prod`, and should be changed to:
+Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.yml'` in the `environment` section for `drupal-prod`, and should be changed to:
 
 ```
 DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -50,7 +50,7 @@ After doing `docker compose down`, run `docker compose up -d --remove-orphans` t
 
 By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN}`. If you do not want to expose your Fedora, you can stop this URL from working by disabling it via Traefik in your `docker-compose.yml`. To do this, you need to add the `traefik-disable` label to `fcrepo-prod` like this,
 
-```
+```yaml
     fcrepo-prod:
         <<: [*prod, *fcrepo]
         environment:

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -62,7 +62,7 @@ By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN
 
 If you have done this, you can also remove the DNS records that point this URL to your production server.
 
-Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.yml'` in the `environment` section for `drupal-prod`, and should be changed to:
+Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.yml` in the `environment` section for `drupal-prod`, and should be changed to:
 
 ```yaml
 DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -60,7 +60,7 @@ By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN
             <<: [*traefik-disable, *fcrepo-labels]
 ```
 
-If you have done this, you can also remove the DNS records that point this URL to your prodcution server.
+If you have done this, you can also remove the DNS records that point this URL to your production server.
 
 Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.yml'` in the `environment` section for `drupal-prod`, and should be changed to:
 

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -64,6 +64,6 @@ If you have done this, you can also remove the DNS records that point this URL t
 
 Finally, you will have to change the URL that Drupal uses to access the Fedora repo. This can be found in your `docker-compose.yml'` in the `environment` section for `drupal-prod`, and should be changed to:
 
-```
+```yaml
 DRUPAL_DEFAULT_FCREPO_URL: "http://fcrepo:8080/fcrepo/rest/"
 ```

--- a/docs/installation/docker/site-template/docker-modifications.md
+++ b/docs/installation/docker/site-template/docker-modifications.md
@@ -48,7 +48,7 @@ After doing `docker compose down`, run `docker compose up -d --remove-orphans` t
 
 ## Hiding Fedora From the Public
 
-By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN}`. If you do not want to expose your Fedora, you can stop this URL from working by disabling it via Traefik in your `docker-compose.yml`. To do this, you need to add the `traefik-disable` label to fcrepo-prod like this,
+By default, your Fedora repo will be available to the public at `fcrepo.${DOMAIN}`. If you do not want to expose your Fedora, you can stop this URL from working by disabling it via Traefik in your `docker-compose.yml`. To do this, you need to add the `traefik-disable` label to `fcrepo-prod` like this,
 
 ```
     fcrepo-prod:


### PR DESCRIPTION
## Purpose / why
How to hide fedora from the public in production

## What changes were made?
added instructions

## Verification
To test this, spin up a production site, and access the fedora repo at fcrepo.${DOMAIN}. Then make the changes described in this PR, and try to access that domain again.

## Interested Parties
* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
