### PR TITLE
Remove reference to .env being tracked in isle-site-template

### DIFF
--- a/docs/installation/docker/site-template/setup.md
+++ b/docs/installation/docker/site-template/setup.md
@@ -31,7 +31,10 @@ This documentation assumes you will be building your production image on the pro
 
 ## Adding a Staging Site
 
-The process for setting up a staging site is the same as production, but you will need to use a different URL. Since the URL is set in the `.env` file, which is checked into your git repository, you may wish to use `docker-compose.override.yml` for this. In `docker-compose.override.yml` you will need to override anywhere the `DOMAIN` variable is used, for example:
+The process for setting up a staging site is the same as production, but you will need to use a different URL. You have two options:
+
+1. You can override the `DOMAIN` environment variable on your staging server
+2. Use `docker-compose.override.yml` for this. In `docker-compose.override.yml` you will need to override anywhere the `DOMAIN` variable is used, for example:
 
 ```
 services:

--- a/docs/installation/docker/site-template/setup.md
+++ b/docs/installation/docker/site-template/setup.md
@@ -33,7 +33,7 @@ This documentation assumes you will be building your production image on the pro
 
 The process for setting up a staging site is the same as production, but you will need to use a different URL. You have two options:
 
-1. You can override the `DOMAIN` environment variable on your staging server
+1. You can override the `DOMAIN` environment variable on your staging server by editing its `.env` file
 2. Use `docker-compose.override.yml` for this. In `docker-compose.override.yml` you will need to override anywhere the `DOMAIN` variable is used, for example:
 
 ```


### PR DESCRIPTION
## Purpose / why

Once https://github.com/Islandora-Devops/isle-site-template/pull/95 merges, the default for isle-site-template will be to not track `.env` files in git.

## What changes were made?

Updates the section in the isle-site-template documentation that mentions `.env` is being tracked

## Interested Parties
* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
