### PR TITLE
Update uploading-large-files.md with traefik command

### DIFF
--- a/docs/user-documentation/uploading-large-files.md
+++ b/docs/user-documentation/uploading-large-files.md
@@ -18,6 +18,16 @@ If you really want to upload large files, you should consider some alternatives 
 - Using the [TUS file upload protocol](https://www.drupal.org/project/tus) module, which will let you upload large files in forms.
 - Using [flysystem](https://www.drupal.org/project/flysystem)'s ftp and sftp plugins to make files available if you can run an FTP server.
 
+### Traefik
+
+If you are using Traefik as a reverse proxy (eg. you are running Isle-DC or Isle Site Template) and you have increased your PHP/nginx timeouts, you will also need to increase Traefik's default timeout. You can do this in the "command" section of your `docker-compose.yml` by adding
+```
+command: >-
+      ...
+      --entryPoints.https.transport.respondingTimeouts.readTimeout=3600
+      ...
+```
+
 ## Large Files and Fedora
 
 If loading large (e.g. range 30-45 GB) files into Fedora, you may need to change the 
@@ -36,4 +46,3 @@ max.request.size.MB=2000
 # Maximum size of an uploaded file kept in memory. Otherwise temporarily persisted to disk.
 max.in.memory.file.size.MB=4
 ```
-


### PR DESCRIPTION
## Purpose / why
traefik has its own timeout that will stop large files from being uploaded

## What changes were made?
added config change that lets you specify traefik's timeout

## Verification
Try to upload a large file (1GB) before and after this change

## Interested Parties

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
