### PR TITLE
Fix zensical preview in site hierarchy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apk add --no-cache git && \
     pip install uv && uv --version && \
     uv pip install --break-system-packages --system zensical==0.0.29
 
+COPY zensical_hooks.py /tmp/zensical_hooks.py
+RUN python3 -c \
+    "import site, shutil; shutil.copy('/tmp/zensical_hooks.py', site.getsitepackages()[0] + '/zensical_hooks.py')"
+
 EXPOSE 8080
 
 ENTRYPOINT ["zensical"]

--- a/docs/installation/docker/site-template/site-template.md
+++ b/docs/installation/docker/site-template/site-template.md
@@ -2,8 +2,8 @@
 
 ## What is the ISLE Site Template?
 
-The [ISLE Site Template][ISLE Site Template] is a system for installing
-Islandora on Docker. As with ISLE-DC, it uses [Docker Compose][Docker Compose]
+The [ISLE Site Template] is a system for installing
+Islandora on Docker. As with ISLE-DC, it uses [Docker Compose]
 to orchestrate the installation of all the different services (Docker
 containers) that make up Islandora. Unlike ISLE-DC, in ISLE Site Template you
 use Docker Compose commands directly, helping you to get familiar with the
@@ -15,7 +15,7 @@ kinds of commands that will be a key part of running and maintaining Islandora.
     * Click the green "Use this template" button on the [ISLE Site Template][ISLE Site Template]
       repository to create your own copy. This creates a new repository in your GitHub account
       with the same directory structure and files, including a pre-installed copy of the
-      [Islandora Starter Site][Islandora Starter Site].
+      [Islandora Starter Site].
 
 2. **Clone your new repository**
     * After creating your repository from the template, clone it to your local machine or server.
@@ -36,6 +36,6 @@ kinds of commands that will be a key part of running and maintaining Islandora.
       custom Drupal codebase is part of the repository and gets built into a custom Docker
       image. 
 
-[ISLE Site Template]: https://github.com/Islandora-Devops/isle-site-template
-[Docker Compose]: https://docs.docker.com/compose/ 
-[Islandora Starter Site]: https://github.com/Islandora-Devops/islandora-starter-site
+[ISLE Site Template]: ../../../user-documentation/glossary.md#isle-site-template
+[Docker Compose]: ../../../user-documentation/glossary.md#docker-compose
+[Islandora Starter Site]: ../../../user-documentation/glossary.md#islandora-starter-site

--- a/docs/installation/docker/site-template/site-template.md
+++ b/docs/installation/docker/site-template/site-template.md
@@ -35,7 +35,3 @@ kinds of commands that will be a key part of running and maintaining Islandora.
       configuration, service settings, Drupal modules, themes, and site configuration. Your
       custom Drupal codebase is part of the repository and gets built into a custom Docker
       image. 
-
-[ISLE Site Template]: ../../../user-documentation/glossary.md#isle-site-template
-[Docker Compose]: ../../../user-documentation/glossary.md#docker-compose
-[Islandora Starter Site]: ../../../user-documentation/glossary.md#islandora-starter-site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
   logo: 'assets/Islandora_logo.png'
 
 markdown_extensions:
+  - zensical_hooks
   - abbr
   - admonition
   - attr_list
@@ -80,7 +81,6 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
-
 
 extra_css:
   - css/custom.css

--- a/zensical_hooks.py
+++ b/zensical_hooks.py
@@ -1,0 +1,106 @@
+"""
+Python-Markdown extension: fix glossary link depth and inject data-preview.
+
+Background
+----------
+Zensical's LinksProcessor always prepends exactly one extra "../" to non-index
+relative links when use_directory_urls=True.  Because includes/abbreviations.md
+uses "../user-documentation/glossary.md#term" (one leading ".."), LinksProcessor
+always emits "../../user-documentation/glossary/#term" in HTML regardless of
+actual page depth:
+
+  depth-2 page (something/page/):        ../../  -> root  OK
+  depth-4 page (a/b/c/page/):            ../../  -> a/b/  WRONG
+
+Separately, zensical.extensions.preview adds data-preview="" by resolving the
+original .md href relative to the current source file.  For deeply nested pages
+the relative "../user-documentation/glossary.md" doesn't resolve to
+"user-documentation/glossary.md", so data-preview is never added.
+
+Fix
+---
+Register a Treeprocessor at priority -1 (lower than the priority-0 processors
+PreviewProcessor and LinksProcessor). It runs after both, reads the current
+page's source path from Zensical's `zrelpath` processor, computes the correct
+depth, rewrites every glossary href, and adds data-preview="" where absent.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from markdown import Extension
+from markdown.treeprocessors import Treeprocessor
+from zensical.extensions.links import LinksProcessor
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
+
+# Matches the relative prefix (any number of ../) before the glossary path
+_GLOSSARY_RE = re.compile(r"^(?:\.\./)*user-documentation/glossary/")
+
+
+def _url_depth(src_path: str) -> int:
+    """Return URL depth with use_directory_urls=True.
+
+    - index.md / README.md at directory depth D  ->  D
+    - any other .md at directory depth D          ->  D + 1
+    """
+    parts = src_path.replace("\\", "/").split("/")
+    is_index = parts[-1].lower() in ("index.md", "readme.md")
+    return len(parts) - 1 if is_index else len(parts)
+
+
+def _find_page_path(md) -> str | None:
+    """Return the source path of the page being rendered.
+
+    This repo ships a Docker-pinned Zensical version that always registers the
+    links treeprocessor as ``zrelpath``.
+    """
+    try:
+        idx = md.treeprocessors.get_index_for_name("zrelpath")
+        proc = md.treeprocessors[idx]
+        if isinstance(proc, LinksProcessor) and isinstance(proc.path, str):
+            return proc.path
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None
+
+
+class GlossaryFixProcessor(Treeprocessor):
+    """Rewrite glossary hrefs to the correct depth and ensure data-preview."""
+
+    def run(self, root: Element) -> None:
+        try:
+            path = _find_page_path(self.md)
+            if path is None:
+                return
+            depth = _url_depth(path)
+            prefix = "../" * depth
+        except Exception:  # noqa: BLE001
+            return
+
+        for el in root.iter("a"):
+            href = el.get("href", "")
+            if "user-documentation/glossary/" not in href:
+                continue
+
+            new_href = _GLOSSARY_RE.sub(
+                prefix + "user-documentation/glossary/", href
+            )
+            if new_href != href:
+                el.set("href", new_href)
+
+            if "data-preview" not in el.attrib:
+                el.set("data-preview", "")
+
+
+class GlossaryFixExtension(Extension):
+    def extendMarkdown(self, md) -> None:  # noqa: N802
+        md.treeprocessors.register(GlossaryFixProcessor(md), "glossary_fix", -1)
+
+
+def makeExtension(**kwargs):  # noqa: N802
+    return GlossaryFixExtension(**kwargs)


### PR DESCRIPTION
One doc page used Reference-style links. e.g `[API][api-link]`

I searched our codebase for this old pattern's use with 
```bash
$ rg --pcre2 -n '\[([^\]]+)\]\[\1\]' ./docs
./docs/installation/docker/site-template/site-template.md
5:The [ISLE Site Template][ISLE Site Template] is a system for installing
6:Islandora on Docker. As with ISLE-DC, it uses [Docker Compose][Docker Compose]
15:    * Click the green "Use this template" button on the [ISLE Site Template][ISLE Site Template]
18:      [Islandora Starter Site][Islandora Starter Site].
```

So only `./docs/installation/docker/site-template/site-template.md` was doing this it seems.

But this unearthered a bug in our snippets/preview logic with the glossary that showed itself when using previews in markdown files deeper in the site hierarchy. The hook added should fix it going forward for any new pages. Here's the fixed page: https://islandora.github.io/documentation/pr-preview/pr-2401/installation/docker/site-template/site-template/