### PR TITLE
Make Seth Shaw and emeritus committer

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -42,7 +42,6 @@ The following is an alphabetized list of the current Islandora committers:
 | Annie Oelschlager           | Northern Illinois University          | aOelschlager   |
 | Alexander O'Neill           | Born-Digital                          | alxp           |
 | Don Richards                | Johns Hopkins University              | DonRichards    |
-| Seth Shaw                   | University of Nevada, Las Vegas       | seth-shaw-unlv |
 | Alan Stanley                | Agile Humanities                      | ajstanley      |
 | Yamil Suarez                | Berklee College of Music              | ysuarez        |
 | Adam Vessey                 | discoverygarden                       | adam-vessey    |
@@ -65,6 +64,7 @@ The following is an alphabetized list of the prior Islandora committers:
 | Paul Pound                  | University of Prince Edward Island|
 | Nick Ruest                  | York University                   |
 | Bethany Seeger              | Johns Hopkins University          |
+| Seth Shaw                   | University of Nevada, Las Vegas & Arizona State University |
 | Jared Whiklo                | University of Manitoba            |
 | Eli Zoller                  | Arizona State University          |
 


### PR DESCRIPTION
Updated Seth Shaw's affiliation to include Arizona State University.

## Purpose / why

Seth is taking a new position at the start of next month without any Islandora responsibilities.

## What changes were made?

Moved Seth to the emeritus committers list.

## Interested Parties

@Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
