### PR TITLE
Change default site URL and simplify demo content setup

### DIFF
--- a/docs/installation/docker/converting.md
+++ b/docs/installation/docker/converting.md
@@ -26,7 +26,7 @@ The default dev environment uses `http` rather than `https`. Running `https` in 
 
 ### Default domain
 
-Using `http` also forced moving away from `islandora.dev`... HSTS rules in Google Chrome in particular do not allow accessing `*.dev` domains over http. So the default development domain is now `islandora.traefik.me`
+Using `http` also forced moving away from `islandora.dev`... HSTS rules in Google Chrome in particular do not allow accessing `*.dev` domains over http. So the default development domain is now `islandora.io`
 
 ### traefik labels to YML
 
@@ -268,7 +268,7 @@ If you want to keep running TLS in your dev environment you can run this make he
 make traefik-https-mkcert
 ```
 
-Otherwise, be sure your `DOMAIN` value in `.env` is `islandora.traefik.me` and be aware your dev site is available at http://islandora.traefik.me
+Otherwise, be sure your `DOMAIN` value in `.env` is `islandora.io` and be aware your dev site is available at http://islandora.io
 
 Now, bring up your services. In a development environment, after running `make up` your ISLE site should be available at `${URI_SCHEME}://${DOMAIN}` (the actual value will print after running make up depending on your settings).
 

--- a/docs/installation/docker/site-template/setup.md
+++ b/docs/installation/docker/site-template/setup.md
@@ -18,7 +18,7 @@ The `make up` command handles:
 - Building the custom Drupal Docker image
 - Starting all services with smart port allocation
 
-By default, your site will be available at `http://islandora.traefik.me` (which resolves to 127.0.0.1).
+By default, your site will be available at `http://islandora.io` (which resolves to 127.0.0.1).
 
 ## Custom Drupal Image
 
@@ -55,32 +55,7 @@ If you need more fine-grained control, you can create a `docker-compose.override
 
 If you are spinning up a new site for testing, you can add some demo content to your site by running
 ```
-[ -d "islandora_workbench" ] || (git clone https://github.com/mjordan/islandora_workbench)
-
-[ -d "islandora_workbench/islandora_demo_objects" ] || git clone https://github.com/Islandora-Devops/islandora_demo_objects.git islandora_workbench/islandora_demo_objects
-
-docker build \
-  --build-arg USER_ID=$(id -u) \
-  --build-arg GROUP_ID=$(id -g) \
-  -t workbench-docker:latest \
-  islandora_workbench
-
-perl -i -pe 's#^host.*#host: "http://islandora.traefik.me"#g' islandora_workbench/islandora_demo_objects/create_islandora_objects.yml
-
-perl -i -pe 's#^input_dir.*#input_dir: "islandora_demo_objects"#g' islandora_workbench/islandora_demo_objects/create_islandora_objects.yml
-
-perl -i -pe 's#^input_csv.*#input_csv: "create_islandora_objects.csv"#g' islandora_workbench/islandora_demo_objects/create_islandora_objects.yml
-
-grep secure_ssl_only islandora_workbench/islandora_demo_objects/create_islandora_objects.yml || echo 'secure_ssl_only: false' >> islandora_workbench/islandora_demo_objects/create_islandora_objects.yml
-
-pushd islandora_workbench
-docker run -it --rm \
-  --network="host" \
-  -v .:/workbench \
-  --name my-running-workbench \
-  workbench-docker:latest \
-  bash -lc "./workbench --config islandora_demo_objects/create_islandora_objects.yml"
-popd
+make demo-objects
 ```
 
 ## Custom Themes & Modules


### PR DESCRIPTION
Updated the default site URL from 'http://islandora.traefik.me' to 'http://islandora.io' and replaced demo content setup instructions with a single command.

## Purpose / why
<!-- Restate the purpose/justification of this work and include links to any Issues or other discussions that are related to this work. -->

## What changes were made?
<!-- State clearly the direct additions or modifications made in this pull request. -->

## Verification
<!-- Document the details that help a reviewer verify the documentation. -->

## Interested Parties
<!-- Name some folks who may be interested, if documentation related mention @Islandora/documentation, or, if unsure, @Islandora/committers_ -->

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
