### PR TITLE
Fix Contributor License Agreement links in editing-docs.md

### DIFF
--- a/docs/contributing/editing-docs.md
+++ b/docs/contributing/editing-docs.md
@@ -18,8 +18,8 @@ To edit documentation in Islandora, you must:
 - be willing to learn [Markdown](http://en.wikipedia.org/wiki/Markdown) - a good [Markdown cheat sheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) can help.
     - for example, you may use Markdown syntax to create links and section headings.
 - follow the [Islandora Documentation Style Guide](docs-style-guide.md).
-- have either an individual [Contributor License Agreement](https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements) (CLA) on file with the Islandora Foundation, or work for an organization that has a corporate Contributor License Agreement on file with the Islandora Foundation.
-    - for information on how to fill out and submit a Contributor License Agreement (CLA) for yourself and/or your organization visit the [License Agreements](https://islandora.github.io/documentation/contributing/CONTRIBUTING/#license-agreements) section of the "How to contribute" documentation page.
+- have either an individual [Contributor License Agreement](https://github.com/Islandora/islandora-community/wiki/Contributor-License-Agreements) (CLA) on file with the Islandora Foundation, or work for an organization that has a corporate Contributor License Agreement on file with the Islandora Foundation.
+    - for information on how to fill out and submit a Contributor License Agreement (CLA) for yourself and/or your organization visit the [License Agreements](https://github.com/Islandora/documentation/blob/main/CONTRIBUTING.md) section of the "How to contribute" documentation page.
 - by participating in the Islandora Community, you are agreeing to act according to the [Islandora Code of Conduct](https://www.islandora.ca/code-of-conduct).
 
 ## How to edit documentation using a web browser


### PR DESCRIPTION
Links to CLAs were broken. 

## Caveat/Question

However, this also revealed that the soft link pointing to the CONTRIBUTING document is gone. In older versions we had `[this repo]/docs/contributing/CONTRIBUTING.md -> ../../CONTRIBUTING.md` such that `https://islandora.github.io/documentation/contributing/CONTRIBUTING/#license-agreements` would resolve.

In this PR I point instead to the CONTRIBUTING.md "blob" on Github. If we can replace the soft link it might be nicer (stay within the github.io system) but it's also fragile and non-UNIX systems might not be able to handle it? 

* @Islandora/documentation
* @Islandora/committers

## Checklist

### Pull-request Reviewer
Pull-request reviewer should ensure the following:

* [ ] Does this PR link to related [issues](https://github.com/Islandora/documentation/issues/)?
* [ ] Does the proposed documentation align with the [Islandora Documentation Style Guide](https://islandora.github.io/documentation/contributing/docs_style_guide/)?
* [ ] Are the changes accurate, useful, free of typos, etc?

### Person Merging
The person merging should ensure the following:

* [ ] Does mkdocs still build successfully? (This is indicated by TravisCI passing. To test locally, and see warnings, see [How To Build Documentation](https://islandora.github.io/documentation/technical-documentation/docs-build/).)
* [ ] If pages are renamed or removed, have all internal links to those pages been fixed?
* [ ] If pages are added, have they been linked to or placed in the menu?
* [ ] Did the PR receive at least one approval from a committer, and all issues raised have been addressed?
